### PR TITLE
Fix issue #28

### DIFF
--- a/lib/cyclid/controllers/organizations/collection.rb
+++ b/lib/cyclid/controllers/organizations/collection.rb
@@ -43,7 +43,9 @@ module Cyclid
               org['owner_email'] = payload['owner_email']
 
               # Add each provided user to the Organization
-              org.users = payload['users'].map do |username|
+              users = payload['users'] || []
+
+              org.users = users.map do |username|
                 user = User.find_by(username: username)
 
                 halt_with_json_response(404, \


### PR DESCRIPTION
Use an empty list of users if no users were given as part of the organization definition.
