### PR TITLE
Improve the path-matching regex

### DIFF
--- a/app/cyclid/plugins/source/git.rb
+++ b/app/cyclid/plugins/source/git.rb
@@ -48,7 +48,7 @@ module Cyclid
 
             branch = source[:branch]
 
-            match = url.path.match(%r{^.*\/(\w*)})
+            match = url.path.match(%r{^.*\/([^\.]*)})
             source_dir = "#{ctx[:workspace]}/#{match[1]}"
 
             success = transport.exec("git fetch origin #{branch}:#{branch}", source_dir)


### PR DESCRIPTION
Improve the regex used to extract the "path" portion of the Git URL so that
it can match valid characters such as '-'