### PR TITLE
Swallow more SSH connection errors

### DIFF
--- a/app/cyclid/plugins/transport/ssh.rb
+++ b/app/cyclid/plugins/transport/ssh.rb
@@ -52,8 +52,10 @@ module Cyclid
                                         keys: keys,
                                         timeout: 5)
               break unless @session.nil?
-            rescue Net::SSH::AuthenticationFailed
+            rescue Net::SSH::Exception
               Cyclid.logger.debug 'SSH authentication failed'
+            rescue StandardError => ex
+              Cyclid.logger.debug "SSH connection failed: #{ex}"
             end
 
             sleep 5


### PR DESCRIPTION
Make the SSH transport more resiliant by catching the more generic
Net:SSH:Exception class *and* catching StandardError (for things like
ECONNREFUSED)