### PR TITLE
Ubuntu & Debian cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pkg
 
 config/local
 config/mist-local
+config/gcp.json
 
 # OS artifacts
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :development, :test do
   gem 'rack-test'
   gem 'yard'
   gem 'sqlite3'
+  gem 'mysql2'
   gem 'webmock'
   gem 'rubygems-tasks'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
       spoon
 
 PATH
-  remote: ../Cyclid-core/
+  remote: ../Cyclid-core
   specs:
     cyclid-core (0.1.1)
       rack (~> 1.6)
@@ -298,4 +298,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
     minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
+    mysql2 (0.4.5)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -284,6 +285,7 @@ DEPENDENCIES
   guard
   guard-rack!
   guard-sidekiq
+  mysql2
   rack-test
   rake
   rb-inotify (~> 0.9.7)

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :redis do
 end
 
 task :sidekiq do
-  exec 'sidekiq -r ./init.rb'
+  exec 'sidekiq -r ./lib/cyclid/app.rb'
 end
 
 task :default do

--- a/app/cyclid/plugins/provisioner/debian.rb
+++ b/app/cyclid/plugins/provisioner/debian.rb
@@ -25,6 +25,10 @@ module Cyclid
         def prepare(transport, buildhost, env = {})
           transport.export_env('DEBIAN_FRONTEND' => 'noninteractive')
 
+          # Build hosts may require an update before anything can be installed
+          success = transport.exec 'apt-get update'
+          raise 'failed to update repositories' unless success
+
           if env.key? :repos
             env[:repos].each do |repo|
               next unless repo.key? :url
@@ -39,6 +43,7 @@ module Cyclid
               end
             end
 
+            # We must update again to cache the new repositories
             success = transport.exec 'apt-get update'
             raise 'failed to update repositories' unless success
           end

--- a/app/cyclid/plugins/provisioner/ubuntu.rb
+++ b/app/cyclid/plugins/provisioner/ubuntu.rb
@@ -25,6 +25,10 @@ module Cyclid
         def prepare(transport, buildhost, env = {})
           transport.export_env('DEBIAN_FRONTEND' => 'noninteractive')
 
+          # Build hosts may require an update before anything can be installed
+          success = transport.exec 'apt-get update'
+          raise 'failed to update repositories' unless success
+
           if env.key? :repos
             # Ensure apt-get-repository is available
             transport.exec 'apt-get install -y software-properties-common'
@@ -45,6 +49,7 @@ module Cyclid
               end
             end
 
+            # We must update again to cache the new repositories
             success = transport.exec 'apt-get update'
             raise 'failed to update repositories' unless success
           end

--- a/app/cyclid/plugins/transport/ssh.rb
+++ b/app/cyclid/plugins/transport/ssh.rb
@@ -122,16 +122,10 @@ module Cyclid
 
         # Close the SSH connection
         def close
-          logout
-
           @session.close
         end
 
         private
-
-        def logout
-          exec 'exit'
-        end
 
         def build_command(cmd, path = nil, env = {})
           command = []


### PR DESCRIPTION
Make the provisioners more reliable (especially on Digitalocean)
Remove the redundant exec of "exit" from the SSH transport.