### PR TITLE
Fix more problems with PR's from Forks

### DIFF
--- a/spec/plugins/api/github/methods_spec.rb
+++ b/spec/plugins/api/github/methods_spec.rb
@@ -98,10 +98,11 @@ describe Cyclid::API::Plugins::ApiExtension::GithubMethods do
         .to_return(status: 200, body: tree, headers: { 'Content-Type' => 'application/vnd.github.v3+json' })
 
       config = { 'repository_tokens' => [], 'oauth_token' => '123456789' }
-      pr = { 'head' => { 'sha' => '1234567890',
+      pr = { 'statuses_url' => 'http://example.com/example/test/status/{sha}',
+             'base' => { 'repo' => { 'html_url' => 'http://example.com/example/test' } },
+             'head' => { 'sha' => '1234567890',
                          'ref' => 'abcdefg',
-                         'repo' => { 'statuses_url' => 'http://example.com/example/test/status/{sha}',
-                                     'html_url' => 'http://example.com/example/test',
+                         'repo' => { 'html_url' => 'http://example.com/example/test',
                                      'trees_url' => 'http://example.com/example/test/tree{/sha}' } } }
       headers = { 'X-Github-Event' => 'pull_request', 'X-Github-Delivery' => '' }
       expect(@methods).to receive(:parse_request_body).and_return('action' => 'opened', 'pull_request' => pr)
@@ -128,10 +129,11 @@ describe Cyclid::API::Plugins::ApiExtension::GithubMethods do
         .to_return(status: 200, body: job_blob.to_json, headers: {})
 
       config = { 'repository_tokens' => [], 'oauth_token' => '123456789' }
-      pr = { 'head' => { 'sha' => '1234567890',
+      pr = { 'statuses_url' => 'http://example.com/example/test/status/{sha}',
+             'base' => { 'repo' => { 'html_url' => 'http://example.com/example/test' } },
+             'head' => { 'sha' => '1234567890',
                          'ref' => 'abcdefg',
-                         'repo' => { 'statuses_url' => 'http://example.com/example/test/status/{sha}',
-                                     'html_url' => 'http://example.com/example/test',
+                         'repo' => { 'html_url' => 'http://example.com/example/test',
                                      'trees_url' => 'http://example.com/example/test/tree{/sha}' } } }
       headers = { 'X-Github-Event' => 'pull_request', 'X-Github-Delivery' => '' }
       expect(@methods).to receive(:parse_request_body).and_return('action' => 'opened', 'pull_request' => pr)
@@ -159,10 +161,11 @@ describe Cyclid::API::Plugins::ApiExtension::GithubMethods do
         .to_return(status: 200, body: job_blob.to_json, headers: {})
 
       config = { 'repository_tokens' => [], 'oauth_token' => '123456789' }
-      pr = { 'head' => { 'sha' => '1234567890',
+      pr = { 'statuses_url' => 'http://example.com/example/test/status/{sha}',
+             'base' => { 'repo' => { 'html_url' => 'http://example.com/example/test' } },
+             'head' => { 'sha' => '1234567890',
                          'ref' => 'abcdefg',
-                         'repo' => { 'statuses_url' => 'http://example.com/example/test/status/{sha}',
-                                     'html_url' => 'http://example.com/example/test',
+                         'repo' => { 'html_url' => 'http://example.com/example/test',
                                      'trees_url' => 'http://example.com/example/test/tree{/sha}' } } }
       headers = { 'X-Github-Event' => 'pull_request', 'X-Github-Delivery' => '' }
       expect(@methods).to receive(:parse_request_body).and_return('action' => 'opened', 'pull_request' => pr)


### PR DESCRIPTION
Use the correct status URL
Correct the helpers & logic around the PR "head" and "base"; head is always
the *source* and base is always the *target*; always clone from the head and
push updates to the base.
Improve the logic of inserting the Pull Request repository into the sources;
the comment was prescient of the issue, so ensure that the head repository URL
has been normalized into a Cyclid source definition, and then normalize the
entire set of sources so that we *over-write* any existing source definition
for the base repository, with the head repository. This means, for example,
that we don't try to clone github.com/fork/foo on top of
github.com/example/foo.
Updates tests to match these changes.