### PR TITLE
log plugin

### DIFF
--- a/app/cyclid/plugins/action/log.rb
+++ b/app/cyclid/plugins/action/log.rb
@@ -32,7 +32,7 @@ module Cyclid
 
         # Write the log message, with the context data interpolated
         def perform(log)
-          log.write(@message % @ctx)
+          log.write("#{@message % @ctx}\n")
           true
         end
 

--- a/spec/plugins/action/log_spec.rb
+++ b/spec/plugins/action/log_spec.rb
@@ -34,7 +34,7 @@ describe Cyclid::API::Plugins::Log do
       end.to_not raise_error
       expect{ plugin.prepare(transport: nil, ctx: nil) }.to_not raise_error
       expect(plugin.perform(log)).to be true
-      expect(log.data).to eq('this is a message')
+      expect(log.data).to eq("this is a message\n")
     end
 
     it 'logs a message with context data' do
@@ -44,7 +44,7 @@ describe Cyclid::API::Plugins::Log do
       end.to_not raise_error
       expect{ plugin.prepare(transport: nil, ctx: { data: 'message' }) }.to_not raise_error
       expect(plugin.perform(log)).to be true
-      expect(log.data).to eq('this is a message')
+      expect(log.data).to eq("this is a message\n")
     end
   end
 end


### PR DESCRIPTION
Append a newline to the end of every log message generated by the log plugin.