### PR TITLE
Add only_if & not_if logical modifiers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ Style/SpaceBeforeBlockBraces:
   Enabled: false
 Style/AndOr:
   Enabled: false
+Style/SpaceAroundOperators:
+  Enabled: false
+Style/SelfAssignment:
+  Enabled: false
 Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:

--- a/app/cyclid/job/evaluator.rb
+++ b/app/cyclid/job/evaluator.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+# Copyright 2017 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Top level module for the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # Module for Cyclid Job related classes
+    module Job
+      # Evaluator exception class
+      class EvalException < RuntimeError
+      end
+
+      # Evalute an expression for "only_if" & "not_if"
+      class Evaluator
+        class << self
+          def only_if(statement, vars)
+            evaluate(statement, vars)
+          end
+
+          def not_if(statement, vars)
+            not evaluate(statement, vars) # rubocop:disable Style/Not
+          end
+
+          private
+
+          def compare(lvalue, operator, rvalue)
+            case operator
+            # Loose (case insensitive) comparision
+            when '=='
+              lvalue.downcase == rvalue.downcase # rubocop:disable Performance/Casecmp
+            # Case sensitive/value comparision
+            when '===', 'eq'
+              lvalue == rvalue
+            # Not-equal
+            when '!=', 'ne'
+              lvalue != rvalue
+            # Less than
+            when '<', 'lt'
+              lvalue.to_f < rvalue.to_f
+            # Greater than
+            when '>', 'gt'
+              lvalue.to_f > rvalue.to_f
+            # Less than or equal
+            when '<=', 'le'
+              lvalue.to_f <= rvalue.to_f
+            # Greater than or equal
+            when '>=', 'ge'
+              lvalue.to_f >= rvalue.to_f
+            # Not an operator we know
+            else
+              raise EvalException, "unknown operator: #{operator}"
+            end
+          end
+
+          def evaluate(statement, vars)
+            # Replace single % characters with escaped versions and interpolate
+            expr = statement.gsub(/%([^{])/, '%%\1') ** vars
+
+            # Evaluate for both string comparisons:
+            #
+            # 'string1' == 'string2'
+            #
+            # and numbers:
+            #
+            # 1 < 2
+            #
+            # Numbers can be integers, floats or percentages
+            #
+            # Only the ==, != and === operators are recognised for strings. All
+            # operators, including == & != are valid for Numbers: === is not a valid
+            # operator for numbers.
+
+            # rubocop:disable Metrics/LineLength
+            case expr
+            when /\A'(.*)' (==|!=|===) '(.*)'\Z/,
+                 /\A([0-9]*|[0-9]*\.[0-9]*)%? (==|eq|!=|ne|<|lt|>|gt|<=|le|>=|ge) ([0-9]*|[0-9]*\.[0-9]*)%?\Z/
+              compare(Regexp.last_match[1],
+                      Regexp.last_match[2],
+                      Regexp.last_match[3])
+            else
+              raise EvalException, "unable to evaluate #{expr}"
+            end
+            # rubocop:enable Metrics/LineLength
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/cyclid/job/job.rb
+++ b/app/cyclid/job/job.rb
@@ -142,6 +142,10 @@ module Cyclid
                      stage?(job_sequence, job_stage[:on_failure])
             stage_view.on_failure = job_stage[:on_failure]
 
+            # Merge in any modifiers
+            stage_view.only_if = job_stage[:only_if]
+            stage_view.not_if = job_stage[:not_if]
+
             # Store the modified StageView
             stages[stage_view.name.to_sym] = stage_view
           end

--- a/app/cyclid/job/stage.rb
+++ b/app/cyclid/job/stage.rb
@@ -25,7 +25,7 @@ module Cyclid
       # the database object.
       class StageView
         attr_reader :name, :version, :steps
-        attr_accessor :on_success, :on_failure
+        attr_accessor :on_success, :on_failure, :only_if, :not_if
 
         def initialize(arg)
           if arg.is_a? Cyclid::API::Stage

--- a/app/cyclid/monkey_patches.rb
+++ b/app/cyclid/monkey_patches.rb
@@ -9,10 +9,10 @@ class Hash
   end
 
   # Interpolate the data in the ctx hash into any String values
-  def interpolate(ctx)
+  def %(other)
     hmap do |key, value|
       if value.is_a? String
-        { key => value % ctx }
+        { key => value ** other }
       else
         { key => value }
       end
@@ -23,15 +23,42 @@ end
 # Add a method to Array
 class Array
   # Interpolate the data in the ctx hash for each String & Hash item
-  def interpolate(ctx)
+  def %(other)
     map do |entry|
       if entry.is_a? Hash
-        entry.interpolate ctx
+        entry % other
       elsif entry.is_a? String
-        entry % @ctx
+        entry ** other
       else
         entry
       end
     end
+  end
+end
+
+# Add a method to String
+class String
+  # Provide a "safe" version of the % (interpolation) operator; if a key does
+  # not exist in arg, catch the KeyError and insert it as a nil value, and
+  # continue.
+  #
+  # We're using the ** operator as it's one that isn't already used by String,
+  # and it's abusing % already so hey, why not. FTP
+  def **(other)
+    res = nil
+    arg = other ? other.dup : {}
+
+    begin
+      res = self % arg
+    rescue KeyError => ex
+      # Extract the key name from the exception message (sigh)
+      match = ex.message.match(/\Akey{(.*)} not found\Z/)
+      key = match[1]
+
+      # Inject key with a default value and try again
+      arg[key.to_sym] = nil
+    end while res.nil? # rubocop:disable Lint/Loop
+
+    return res
   end
 end

--- a/app/cyclid/plugins/action/command.rb
+++ b/app/cyclid/plugins/action/command.rb
@@ -55,7 +55,7 @@ module Cyclid
         def perform(log)
           begin
             # Export the environment data to the build host, if necesary
-            env = @env.interpolate(@ctx) if @env
+            env = @env % @ctx if @env
             @transport.export_env(env)
 
             # Log the command being run (and the working directory, if one is
@@ -64,11 +64,11 @@ module Cyclid
             log.write(@path.nil? ? "$ #{cmd_args}\n" : "$ #{@path} : #{cmd_args}\n")
 
             # Interpolate any data from the job context
-            cmd_args = cmd_args % @ctx
+            cmd_args = cmd_args ** @ctx
 
             # Interpolate the path if one is set
             path = @path
-            path = path % @ctx unless path.nil?
+            path = path ** @ctx unless path.nil?
 
             # Run the command
             success = @transport.exec(cmd_args, path)

--- a/app/cyclid/plugins/action/email.rb
+++ b/app/cyclid/plugins/action/email.rb
@@ -51,9 +51,9 @@ module Cyclid
                                 "as #{email_config[:from]}"
 
             # Add the job context
-            to = @to % @ctx
-            subject = @subject % @ctx
-            message = @message % @ctx
+            to = @to ** @ctx
+            subject = @subject ** @ctx
+            message = @message ** @ctx
 
             # Create a binding for the text & HTML ERB templates
             info = { color: @color, title: subject }

--- a/app/cyclid/plugins/action/log.rb
+++ b/app/cyclid/plugins/action/log.rb
@@ -32,7 +32,7 @@ module Cyclid
 
         # Write the log message, with the context data interpolated
         def perform(log)
-          log.write(@message % @ctx)
+          log.write("#{@message ** @ctx}\n")
           true
         end
 

--- a/app/cyclid/plugins/action/script.rb
+++ b/app/cyclid/plugins/action/script.rb
@@ -56,12 +56,12 @@ module Cyclid
         def perform(log)
           begin
             # Export the environment data to the build host, if necesary
-            env = @env.interpolate(@ctx) if @env
+            env = @env % @ctx if @env
             @transport.export_env(env)
 
             # Add context data
-            script = @script % @ctx
-            path = @path % @ctx
+            script = @script ** @ctx
+            path = @path ** @ctx
 
             # Create an IO object containing the script and upload it to the
             # build host

--- a/app/cyclid/plugins/action/slack.rb
+++ b/app/cyclid/plugins/action/slack.rb
@@ -43,15 +43,15 @@ module Cyclid
             Cyclid.logger.debug "using plugin config #{plugin_data}"
             config = plugin_data['config']
 
-            subject = @subject % @ctx
+            subject = @subject ** @ctx
 
             url = @url || config['webhook_url']
             raise 'no webhook URL given' if url.nil?
 
-            url = url % @ctx
+            url = url ** @ctx
             Cyclid.logger.debug "sending notification to #{url}"
 
-            message_text = @message % @ctx if @message
+            message_text = @message ** @ctx if @message
 
             # Create a binding for the template
             bind = binding

--- a/app/cyclid/plugins/source/git.rb
+++ b/app/cyclid/plugins/source/git.rb
@@ -32,7 +32,7 @@ module Cyclid
               unless source.key? :url
 
             # Add any context data (which could include secrets)
-            source = source.interpolate(ctx)
+            source = source % ctx
 
             url = URI(source[:url])
 

--- a/spec/core/monkey_patches_spec.rb
+++ b/spec/core/monkey_patches_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe String do
+  describe '#**' do
+    let :s do
+      '%{foo}'
+    end
+
+    it 'interpolates a string' do
+      expect(s ** { foo: 'test' }).to eq 'test'
+    end
+
+    it 'interpolates a string when the key is missing' do
+      expect(s ** { bar: 'test' }).to eq ''
+    end
+  end
+end
+
+describe Hash do
+  describe '#%' do
+    let :h do
+      { foo: '%{foo}', bar: 'bar', baz: 42 }
+    end
+
+    it 'interpolates a hash' do
+      expect(h % { foo: 'test' }).to include(foo: 'test', bar: 'bar', baz: 42)
+    end
+  end
+end
+
+describe Array do
+  describe '#%' do
+    let :a do
+      ['%{foo}', { bar: '%{bar}' }, 'baz', 42]
+    end
+
+    it 'interpolates an array' do
+      expect(a % { foo: 'foo', bar: 'bar' }).to include('foo', { bar: 'bar' }, 'baz', 42)
+    end
+  end
+end

--- a/spec/job/evaluator_spec.rb
+++ b/spec/job/evaluator_spec.rb
@@ -1,0 +1,656 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Cyclid::API::Job::Evaluator do
+  describe '.only_if' do
+    context 'with eq' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 eq 1', {})).to be true
+        expect(described_class.only_if('1 eq 0', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 eq 1.0', {})).to be true
+        expect(described_class.only_if('1.0 eq 0.1', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% eq 90%', {})).to be true
+        expect(described_class.only_if('90% eq 100%', {})).to be false
+      end
+    end
+
+    context 'with ==' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 == 1', {})).to be true
+        expect(described_class.only_if('1 == 0', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 == 1.0', {})).to be true
+        expect(described_class.only_if('1.0 == 0.1', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% == 90%', {})).to be true
+        expect(described_class.only_if('90% == 100%', {})).to be false
+      end
+
+      it 'compares strings' do
+        expect(described_class.only_if("'foo' == 'foo'", {})).to be true
+        expect(described_class.only_if("'foo' == 'bar'", {})).to be false
+        expect(described_class.only_if("'foo' == 'FOO'", {})).to be true
+        expect(described_class.only_if("'foo' == 'BAR'", {})).to be false
+        expect(described_class.only_if("'this is a string' == 'this is a string'", {})).to be true
+        expect(described_class.only_if("'this is a string' == 'THIS IS A STRING'", {})).to be true
+        expect(described_class.only_if("'this is a string' == 'this is a test'", {})).to be false
+        expect(described_class.only_if("'this is a string' == 'THIS IS A TEST'", {})).to be false
+      end
+
+      it 'compares empty strings' do
+        expect(described_class.only_if("'' == ''", {})).to be true
+        expect(described_class.only_if("'foo' == ''", {})).to be false
+        expect(described_class.only_if("'' == 'foo'", {})).to be false
+      end
+    end
+
+    context 'with ===' do
+      it 'compares strings' do
+        expect(described_class.only_if("'foo' === 'foo'", {})).to be true
+        expect(described_class.only_if("'foo' === 'bar'", {})).to be false
+        expect(described_class.only_if("'foo' === 'FOO'", {})).to be false
+        expect(described_class.only_if("'foo' === 'BAR'", {})).to be false
+        expect(described_class.only_if("'this is a string' === 'this is a string'", {})).to be true
+        expect(described_class.only_if("'this is a string' === 'THIS IS A STRING'", {})).to be false
+        expect(described_class.only_if("'this is a string' === 'this is a test'", {})).to be false
+        expect(described_class.only_if("'this is a string' === 'THIS IS A TEST'", {})).to be false
+      end
+
+      it 'compares empty strings' do
+        expect(described_class.only_if("'' === ''", {})).to be true
+        expect(described_class.only_if("'foo' === ''", {})).to be false
+        expect(described_class.only_if("'' === 'foo'", {})).to be false
+      end
+    end
+
+    context 'with ne' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 ne 1', {})).to be false
+        expect(described_class.only_if('1 ne 0', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 ne 1.0', {})).to be false
+        expect(described_class.only_if('1.0 ne 0.1', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% ne 90%', {})).to be false
+        expect(described_class.only_if('90% ne 100%', {})).to be true
+      end
+    end
+
+    context 'with !=' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 != 1', {})).to be false
+        expect(described_class.only_if('1 != 0', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 != 1.0', {})).to be false
+        expect(described_class.only_if('1.0 != 0.1', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% != 90%', {})).to be false
+        expect(described_class.only_if('90% != 100%', {})).to be true
+      end
+
+      it 'compares strings' do
+        expect(described_class.only_if("'foo' != 'foo'", {})).to be false
+        expect(described_class.only_if("'foo' != 'bar'", {})).to be true
+        expect(described_class.only_if("'foo' != 'FOO'", {})).to be true
+        expect(described_class.only_if("'foo' != 'BAR'", {})).to be true
+        expect(described_class.only_if("'this is a string' != 'this is a string'", {})).to be false
+        expect(described_class.only_if("'this is a string' != 'THIS IS A STRING'", {})).to be true
+        expect(described_class.only_if("'this is a string' != 'this is a test'", {})).to be true
+        expect(described_class.only_if("'this is a string' != 'THIS IS A TEST'", {})).to be true
+      end
+    end
+
+    context 'with lt' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 lt 1', {})).to be false
+        expect(described_class.only_if('1 lt 0', {})).to be false
+        expect(described_class.only_if('0 lt 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 lt 1.0', {})).to be false
+        expect(described_class.only_if('1.0 lt 0.1', {})).to be false
+        expect(described_class.only_if('0.1 lt 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% lt 90%', {})).to be false
+        expect(described_class.only_if('90% lt 100%', {})).to be true
+      end
+    end
+
+    context 'with <' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 < 1', {})).to be false
+        expect(described_class.only_if('1 < 0', {})).to be false
+        expect(described_class.only_if('0 < 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 < 1.0', {})).to be false
+        expect(described_class.only_if('1.0 < 0.1', {})).to be false
+        expect(described_class.only_if('0.1 < 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% < 90%', {})).to be false
+        expect(described_class.only_if('90% < 100%', {})).to be true
+      end
+    end
+
+    context 'with gt' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 gt 1', {})).to be false
+        expect(described_class.only_if('1 gt 0', {})).to be true
+        expect(described_class.only_if('0 gt 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 gt 1.0', {})).to be false
+        expect(described_class.only_if('1.0 gt 0.1', {})).to be true
+        expect(described_class.only_if('0.1 gt 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% gt 90%', {})).to be false
+        expect(described_class.only_if('90% gt 100%', {})).to be false
+        expect(described_class.only_if('100% gt 90%', {})).to be true
+      end
+    end
+
+    context 'with >' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 > 1', {})).to be false
+        expect(described_class.only_if('1 > 0', {})).to be true
+        expect(described_class.only_if('0 > 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 > 1.0', {})).to be false
+        expect(described_class.only_if('1.0 > 0.1', {})).to be true
+        expect(described_class.only_if('0.1 > 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% > 90%', {})).to be false
+        expect(described_class.only_if('90% > 100%', {})).to be false
+        expect(described_class.only_if('100% > 90%', {})).to be true
+      end
+    end
+
+    context 'with le' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 le 1', {})).to be true
+        expect(described_class.only_if('1 le 0', {})).to be false
+        expect(described_class.only_if('0 le 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 le 1.0', {})).to be true
+        expect(described_class.only_if('1.0 le 0.1', {})).to be false
+        expect(described_class.only_if('0.1 le 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% le 90%', {})).to be true
+        expect(described_class.only_if('90% le 100%', {})).to be true
+        expect(described_class.only_if('100% le 90%', {})).to be false
+      end
+    end
+
+    context 'with <=' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 <= 1', {})).to be true
+        expect(described_class.only_if('1 <= 0', {})).to be false
+        expect(described_class.only_if('0 <= 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 <= 1.0', {})).to be true
+        expect(described_class.only_if('1.0 <= 0.1', {})).to be false
+        expect(described_class.only_if('0.1 <= 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% <= 90%', {})).to be true
+        expect(described_class.only_if('90% <= 100%', {})).to be true
+        expect(described_class.only_if('100% <= 90%', {})).to be false
+      end
+    end
+
+    context 'with ge' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 ge 1', {})).to be true
+        expect(described_class.only_if('1 ge 0', {})).to be true
+        expect(described_class.only_if('0 ge 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 ge 1.0', {})).to be true
+        expect(described_class.only_if('1.0 ge 0.1', {})).to be true
+        expect(described_class.only_if('0.1 ge 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% ge 90%', {})).to be true
+        expect(described_class.only_if('90% ge 100%', {})).to be false
+        expect(described_class.only_if('100% ge 90%', {})).to be true
+      end
+    end
+
+    context 'with >=' do
+      it 'compares integers' do
+        expect(described_class.only_if('1 >= 1', {})).to be true
+        expect(described_class.only_if('1 >= 0', {})).to be true
+        expect(described_class.only_if('0 >= 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.only_if('1.0 >= 1.0', {})).to be true
+        expect(described_class.only_if('1.0 >= 0.1', {})).to be true
+        expect(described_class.only_if('0.1 >= 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.only_if('90% >= 90%', {})).to be true
+        expect(described_class.only_if('90% >= 100%', {})).to be false
+        expect(described_class.only_if('100% >= 90%', {})).to be true
+      end
+    end
+
+    context 'interpolating variables' do
+      let :vars do
+        { integer: 42,
+          float: 1.0,
+          percentage: '90%',
+          string1: 'this is a string',
+          string2: 'this is a string with a % symbol' }
+      end
+
+      it 'compares an integer variable' do
+        expect(described_class.only_if('42 eq %{integer}', vars)).to be true
+        expect(described_class.only_if('1 eq %{integer}', vars)).to be false
+      end
+
+      it 'compares a float variable' do
+        expect(described_class.only_if('1.0 eq %{float}', vars)).to be true
+        expect(described_class.only_if('0.1 eq %{float}', vars)).to be false
+      end
+
+      it 'compares a percentage variable' do
+        expect(described_class.only_if('90% eq %{percentage}', vars)).to be true
+        expect(described_class.only_if('100% eq %{percentage}', vars)).to be false
+      end
+
+      it 'compares a string variable' do
+        expect(described_class.only_if("'this is a string' == '%{string1}'", vars)).to be true
+        expect(described_class.only_if("'this is a test' == '%{string1}'", vars)).to be false
+      end
+
+      it 'compares a string variable with a % symbol' do
+        expect(described_class.only_if("'this is a string with a % symbol' == '%{string2}'",
+                                       vars)).to be true
+        expect(described_class.only_if("'this is a test with a % symbol' == '%{string2}'",
+                                       vars)).to be false
+      end
+    end
+
+    context 'with an invalid comparison' do
+      it 'raises an exception' do
+        expect{ described_class.only_if("'foo' == 42", {}) }.to \
+          raise_exception Cyclid::API::Job::EvalException
+      end
+    end
+
+    context 'with an unknown operator' do
+      it 'raises an exception' do
+        expect{ described_class.only_if('1 ~= 1', {}) }.to \
+          raise_exception Cyclid::API::Job::EvalException
+      end
+    end
+  end
+
+  describe '.not_if' do
+    context 'with eq' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 eq 1', {})).to be false
+        expect(described_class.not_if('1 eq 0', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 eq 1.0', {})).to be false
+        expect(described_class.not_if('1.0 eq 0.1', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% eq 90%', {})).to be false
+        expect(described_class.not_if('90% eq 100%', {})).to be true
+      end
+    end
+
+    context 'with ==' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 == 1', {})).to be false
+        expect(described_class.not_if('1 == 0', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 == 1.0', {})).to be false
+        expect(described_class.not_if('1.0 == 0.1', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% == 90%', {})).to be false
+        expect(described_class.not_if('90% == 100%', {})).to be true
+      end
+
+      it 'compares strings' do
+        expect(described_class.not_if("'foo' == 'foo'", {})).to be false
+        expect(described_class.not_if("'foo' == 'bar'", {})).to be true
+        expect(described_class.not_if("'foo' == 'FOO'", {})).to be false
+        expect(described_class.not_if("'foo' == 'BAR'", {})).to be true
+        expect(described_class.not_if("'this is a string' == 'this is a string'", {})).to be false
+        expect(described_class.not_if("'this is a string' == 'THIS IS A STRING'", {})).to be false
+        expect(described_class.not_if("'this is a string' == 'this is a test'", {})).to be true
+        expect(described_class.not_if("'this is a string' == 'THIS IS A TEST'", {})).to be true
+      end
+
+      it 'compares empty strings' do
+        expect(described_class.not_if("'' == ''", {})).to be false
+        expect(described_class.not_if("'foo' == ''", {})).to be true
+        expect(described_class.not_if("'' == 'foo'", {})).to be true
+      end
+    end
+
+    context 'with ===' do
+      it 'compares strings' do
+        expect(described_class.not_if("'foo' === 'foo'", {})).to be false
+        expect(described_class.not_if("'foo' === 'bar'", {})).to be true
+        expect(described_class.not_if("'foo' === 'FOO'", {})).to be true
+        expect(described_class.not_if("'foo' === 'BAR'", {})).to be true
+        expect(described_class.not_if("'this is a string' === 'this is a string'", {})).to be false
+        expect(described_class.not_if("'this is a string' === 'THIS IS A STRING'", {})).to be true
+        expect(described_class.not_if("'this is a string' === 'this is a test'", {})).to be true
+        expect(described_class.not_if("'this is a string' === 'THIS IS A TEST'", {})).to be true
+      end
+
+      it 'compares empty strings' do
+        expect(described_class.not_if("'' === ''", {})).to be false
+        expect(described_class.not_if("'foo' === ''", {})).to be true
+        expect(described_class.not_if("'' === 'foo'", {})).to be true
+      end
+    end
+
+    context 'with ne' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 ne 1', {})).to be true
+        expect(described_class.not_if('1 ne 0', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 ne 1.0', {})).to be true
+        expect(described_class.not_if('1.0 ne 0.1', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% ne 90%', {})).to be true
+        expect(described_class.not_if('90% ne 100%', {})).to be false
+      end
+    end
+
+    context 'with !=' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 != 1', {})).to be true
+        expect(described_class.not_if('1 != 0', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 != 1.0', {})).to be true
+        expect(described_class.not_if('1.0 != 0.1', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% != 90%', {})).to be true
+        expect(described_class.not_if('90% != 100%', {})).to be false
+      end
+
+      it 'compares strings' do
+        expect(described_class.not_if("'foo' != 'foo'", {})).to be true
+        expect(described_class.not_if("'foo' != 'bar'", {})).to be false
+        expect(described_class.not_if("'foo' != 'FOO'", {})).to be false
+        expect(described_class.not_if("'foo' != 'BAR'", {})).to be false
+        expect(described_class.not_if("'this is a string' != 'this is a string'", {})).to be true
+        expect(described_class.not_if("'this is a string' != 'THIS IS A STRING'", {})).to be false
+        expect(described_class.not_if("'this is a string' != 'this is a test'", {})).to be false
+        expect(described_class.not_if("'this is a string' != 'THIS IS A TEST'", {})).to be false
+      end
+    end
+
+    context 'with lt' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 lt 1', {})).to be true
+        expect(described_class.not_if('1 lt 0', {})).to be true
+        expect(described_class.not_if('0 lt 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 lt 1.0', {})).to be true
+        expect(described_class.not_if('1.0 lt 0.1', {})).to be true
+        expect(described_class.not_if('0.1 lt 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% lt 90%', {})).to be true
+        expect(described_class.not_if('90% lt 100%', {})).to be false
+      end
+    end
+
+    context 'with <' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 < 1', {})).to be true
+        expect(described_class.not_if('1 < 0', {})).to be true
+        expect(described_class.not_if('0 < 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 < 1.0', {})).to be true
+        expect(described_class.not_if('1.0 < 0.1', {})).to be true
+        expect(described_class.not_if('0.1 < 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% < 90%', {})).to be true
+        expect(described_class.not_if('90% < 100%', {})).to be false
+      end
+    end
+
+    context 'with gt' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 gt 1', {})).to be true
+        expect(described_class.not_if('1 gt 0', {})).to be false
+        expect(described_class.not_if('0 gt 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 gt 1.0', {})).to be true
+        expect(described_class.not_if('1.0 gt 0.1', {})).to be false
+        expect(described_class.not_if('0.1 gt 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% gt 90%', {})).to be true
+        expect(described_class.not_if('90% gt 100%', {})).to be true
+        expect(described_class.not_if('100% gt 90%', {})).to be false
+      end
+    end
+
+    context 'with >' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 > 1', {})).to be true
+        expect(described_class.not_if('1 > 0', {})).to be false
+        expect(described_class.not_if('0 > 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 > 1.0', {})).to be true
+        expect(described_class.not_if('1.0 > 0.1', {})).to be false
+        expect(described_class.not_if('0.1 > 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% > 90%', {})).to be true
+        expect(described_class.not_if('90% > 100%', {})).to be true
+        expect(described_class.not_if('100% > 90%', {})).to be false
+      end
+    end
+
+    context 'with le' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 le 1', {})).to be false
+        expect(described_class.not_if('1 le 0', {})).to be true
+        expect(described_class.not_if('0 le 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 le 1.0', {})).to be false
+        expect(described_class.not_if('1.0 le 0.1', {})).to be true
+        expect(described_class.not_if('0.1 le 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% le 90%', {})).to be false
+        expect(described_class.not_if('90% le 100%', {})).to be false
+        expect(described_class.not_if('100% le 90%', {})).to be true
+      end
+    end
+
+    context 'with <=' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 <= 1', {})).to be false
+        expect(described_class.not_if('1 <= 0', {})).to be true
+        expect(described_class.not_if('0 <= 1', {})).to be false
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 <= 1.0', {})).to be false
+        expect(described_class.not_if('1.0 <= 0.1', {})).to be true
+        expect(described_class.not_if('0.1 <= 1.0', {})).to be false
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% <= 90%', {})).to be false
+        expect(described_class.not_if('90% <= 100%', {})).to be false
+        expect(described_class.not_if('100% <= 90%', {})).to be true
+      end
+    end
+
+    context 'with ge' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 ge 1', {})).to be false
+        expect(described_class.not_if('1 ge 0', {})).to be false
+        expect(described_class.not_if('0 ge 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 ge 1.0', {})).to be false
+        expect(described_class.not_if('1.0 ge 0.1', {})).to be false
+        expect(described_class.not_if('0.1 ge 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% ge 90%', {})).to be false
+        expect(described_class.not_if('90% ge 100%', {})).to be true
+        expect(described_class.not_if('100% ge 90%', {})).to be false
+      end
+    end
+
+    context 'with >=' do
+      it 'compares integers' do
+        expect(described_class.not_if('1 >= 1', {})).to be false
+        expect(described_class.not_if('1 >= 0', {})).to be false
+        expect(described_class.not_if('0 >= 1', {})).to be true
+      end
+
+      it 'compares floats' do
+        expect(described_class.not_if('1.0 >= 1.0', {})).to be false
+        expect(described_class.not_if('1.0 >= 0.1', {})).to be false
+        expect(described_class.not_if('0.1 >= 1.0', {})).to be true
+      end
+
+      it 'compares percentages' do
+        expect(described_class.not_if('90% >= 90%', {})).to be false
+        expect(described_class.not_if('90% >= 100%', {})).to be true
+        expect(described_class.not_if('100% >= 90%', {})).to be false
+      end
+    end
+
+    context 'interpolating variables' do
+      let :vars do
+        { integer: 42,
+          float: 1.0,
+          percentage: '90%',
+          string1: 'this is a string',
+          string2: 'this is a string with a % symbol' }
+      end
+
+      it 'compares an integer variable' do
+        expect(described_class.not_if('42 eq %{integer}', vars)).to be false
+        expect(described_class.not_if('1 eq %{integer}', vars)).to be true
+      end
+
+      it 'compares a float variable' do
+        expect(described_class.not_if('1.0 eq %{float}', vars)).to be false
+        expect(described_class.not_if('0.1 eq %{float}', vars)).to be true
+      end
+
+      it 'compares a percentage variable' do
+        expect(described_class.not_if('90% eq %{percentage}', vars)).to be false
+        expect(described_class.not_if('100% eq %{percentage}', vars)).to be true
+      end
+
+      it 'compares a string variable' do
+        expect(described_class.not_if("'this is a string' == '%{string1}'", vars)).to be false
+        expect(described_class.not_if("'this is a test' == '%{string1}'", vars)).to be true
+      end
+
+      it 'compares a string variable with a % symbol' do
+        expect(described_class.not_if("'this is a string with a % symbol' == '%{string2}'",
+                                      vars)).to be false
+        expect(described_class.not_if("'this is a test with a % symbol' == '%{string2}'",
+                                      vars)).to be true
+      end
+    end
+
+    context 'with an invalid comparison' do
+      it 'raises an exception' do
+        expect{ described_class.not_if("'foo' == 42", {}) }.to \
+          raise_exception Cyclid::API::Job::EvalException
+      end
+    end
+
+    context 'with an unknown operator' do
+      it 'raises an exception' do
+        expect{ described_class.not_if('1 ~= 1', {}) }.to \
+          raise_exception Cyclid::API::Job::EvalException
+      end
+    end
+  end
+end

--- a/spec/job/runner_spec.rb
+++ b/spec/job/runner_spec.rb
@@ -146,6 +146,90 @@ describe Cyclid::API::Job::Runner do
     expect{ job.run }.to_not raise_error
   end
 
+  context 'with an only_if modifier' do
+    it 'runs a job when the expression evaluates as true' do
+      stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
+      sequence = [{ stage: 'test', only_if: '1 eq 1' }]
+      job_def = { name: 'test',
+                  environment: {},
+                  sources: [],
+                  stages: stages,
+                  sequence: sequence }
+
+      job_view = nil
+      expect{ job_view = Cyclid::API::Job::JobView.new(job_def, {}, @org) }.to_not raise_error
+
+      job_json = nil
+      expect{ job_json = job_view.to_hash.to_json }.to_not raise_error
+
+      job = nil
+      expect{ job = Cyclid::API::Job::Runner.new(4, job_json, @notifier) }.to_not raise_error
+      expect{ job.run }.to_not raise_error
+    end
+
+    it 'runs a job when the expression evaluates as false' do
+      stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
+      sequence = [{ stage: 'test', only_if: '1 eq 0' }]
+      job_def = { name: 'test',
+                  environment: {},
+                  sources: [],
+                  stages: stages,
+                  sequence: sequence }
+
+      job_view = nil
+      expect{ job_view = Cyclid::API::Job::JobView.new(job_def, {}, @org) }.to_not raise_error
+
+      job_json = nil
+      expect{ job_json = job_view.to_hash.to_json }.to_not raise_error
+
+      job = nil
+      expect{ job = Cyclid::API::Job::Runner.new(4, job_json, @notifier) }.to_not raise_error
+      expect{ job.run }.to_not raise_error
+    end
+  end
+
+  context 'with a not_if modifier' do
+    it 'runs a job when the expression evaluates as true' do
+      stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
+      sequence = [{ stage: 'test', not_if: '1 eq 1' }]
+      job_def = { name: 'test',
+                  environment: {},
+                  sources: [],
+                  stages: stages,
+                  sequence: sequence }
+
+      job_view = nil
+      expect{ job_view = Cyclid::API::Job::JobView.new(job_def, {}, @org) }.to_not raise_error
+
+      job_json = nil
+      expect{ job_json = job_view.to_hash.to_json }.to_not raise_error
+
+      job = nil
+      expect{ job = Cyclid::API::Job::Runner.new(5, job_json, @notifier) }.to_not raise_error
+      expect{ job.run }.to_not raise_error
+    end
+
+    it 'runs a job when the expression evaluates as false' do
+      stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
+      sequence = [{ stage: 'test', not_if: '1 eq 0' }]
+      job_def = { name: 'test',
+                  environment: {},
+                  sources: [],
+                  stages: stages,
+                  sequence: sequence }
+
+      job_view = nil
+      expect{ job_view = Cyclid::API::Job::JobView.new(job_def, {}, @org) }.to_not raise_error
+
+      job_json = nil
+      expect{ job_json = job_view.to_hash.to_json }.to_not raise_error
+
+      job = nil
+      expect{ job = Cyclid::API::Job::Runner.new(5, job_json, @notifier) }.to_not raise_error
+      expect{ job.run }.to_not raise_error
+    end
+  end
+
   it 'fails if the job definition is invalid' do
     expect{ Cyclid::API::Job::Runner.new(5, 'this is not valid JSON', @notifier) }.to raise_error
   end

--- a/spec/plugins/action/log_spec.rb
+++ b/spec/plugins/action/log_spec.rb
@@ -34,7 +34,7 @@ describe Cyclid::API::Plugins::Log do
       end.to_not raise_error
       expect{ plugin.prepare(transport: nil, ctx: nil) }.to_not raise_error
       expect(plugin.perform(log)).to be true
-      expect(log.data).to eq('this is a message')
+      expect(log.data).to eq("this is a message\n")
     end
 
     it 'logs a message with context data' do
@@ -44,7 +44,7 @@ describe Cyclid::API::Plugins::Log do
       end.to_not raise_error
       expect{ plugin.prepare(transport: nil, ctx: { data: 'message' }) }.to_not raise_error
       expect(plugin.perform(log)).to be true
-      expect(log.data).to eq('this is a message')
+      expect(log.data).to eq("this is a message\n")
     end
   end
 end


### PR DESCRIPTION
Provide an Evaluator class that can parse & evaluate simple statements in the
form "lvalue operator rvalue", and returns either the result (only_if) or
inverted result (not_if) of the evaluated expression.
The evaluator supports both String and Number comparisions. Strings are in the
form "'lvalue' operator 'rvalue'" I.e. enclosed within single quotes. Numbers
can be integers, floats or percentages.
Operators supported are ==, != and === for Strings, and ==/eq, !=/ne, </lt,
>/gt, <=/lte & >=/gte for Numbers.

Ensure that only_if/not_if expressions are stored in the StageView.
Evaluate any only_if or not_if expression that's defined, and either
run or skip the current stage depending on the outcome; if no
modifier is defined, always run the stage. If the stage is skipped due
to the modifer, proceed as if the Stage has suceeded.

Add String::** to provide a "safe" version of the % (interpolation) method;
** handles missing keys by inserting a nil value, instead of throwing a
KeyError.
Use ** instead of % to provide safe job-context interpolation everywhere.
Rename the Hash::interpolate and Array::interpolate methods to Hash::% and
Array::% to match String; eventually these both fall back to String::** to
both are "safe" by default.