### PR TITLE
Return the HMAC secret from GET /:username

### DIFF
--- a/app/cyclid/controllers/users.rb
+++ b/app/cyclid/controllers/users.rb
@@ -23,9 +23,9 @@ module Cyclid
     class UserController < ControllerBase
       helpers do
         # Remove sensitive data from the users data
-        def sanitize_user(user)
+        def sanitize_user(user, keys = %w(password secret))
           user.delete_if do |key, _value|
-            key == 'password' || key == 'secret'
+            keys.include? key
           end
         end
       end

--- a/app/cyclid/controllers/users/document.rb
+++ b/app/cyclid/controllers/users/document.rb
@@ -78,7 +78,8 @@ module Cyclid
             user_hash = user.serializable_hash
             user_hash['organizations'] = user.organizations.map(&:name)
 
-            user_hash = sanitize_user(user_hash)
+            # DO provide the users HMAC secret, in this instance
+            user_hash = sanitize_user(user_hash, ['password'])
 
             return user_hash.to_json
           end

--- a/spec/api/user_document_spec.rb
+++ b/spec/api/user_document_spec.rb
@@ -25,6 +25,7 @@ describe 'a user document' do
                              'username' => 'admin',
                              'email' => 'admin@example.com',
                              'name' => 'Admin Test',
+                             'secret' => 'aasecret55',
                              'organizations' => ['admins'])
     end
 
@@ -67,6 +68,7 @@ describe 'a user document' do
                              'username' => 'test',
                              'email' => 'testuser@example.com',
                              'name' => 'Test Test',
+                             'secret' => nil,
                              'organizations' => [])
     end
 
@@ -87,6 +89,7 @@ describe 'a user document' do
                              'username' => 'test',
                              'email' => 'testuser@example.com',
                              'name' => 'Bob Dobbs',
+                             'secret' => nil,
                              'organizations' => [])
     end
 


### PR DESCRIPTION
Allow the caller to pass a list of keys to remove in sanitize_user; default to 'password' & 'secret'.
During GET :/username only sanitize the 'password' key and leave 'secret' intact so that users can retrieve their own HMAC secret, and clients can use it to generate valid configuration files.