### PR TITLE
Coverage plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rubocop'
   gem 'simplecov'
+  gem 'simplecov-json'
   gem 'rack-test'
   gem 'yard'
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,9 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    simplecov-json (0.2)
+      json
+      simplecov
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -293,6 +296,7 @@ DEPENDENCIES
   rubocop
   rubygems-tasks
   simplecov
+  simplecov-json
   sqlite3
   webmock
   yard

--- a/app/cyclid/plugins/action/cobertura.rb
+++ b/app/cyclid/plugins/action/cobertura.rb
@@ -40,8 +40,8 @@ module Cyclid
           # Parse the report and extract the line & branch coverage.
           xml = Nokogiri.parse(report.string)
           coverage = xml.xpath('//coverage')
-          line_rate = coverage.attr('line-rate').value.to_i
-          branch_rate = coverage.attr('branch-rate').value.to_i
+          line_rate = coverage.attr('line-rate').value.to_f
+          branch_rate = coverage.attr('branch-rate').value.to_f
 
           # Coverage is given as a fraction, so convert it to a percentage.
           #

--- a/app/cyclid/plugins/action/cobertura.rb
+++ b/app/cyclid/plugins/action/cobertura.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+# Copyright 2016, 2017 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'nokogiri'
+
+# Top level module for the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # Module for Cyclid Plugins
+    module Plugins
+      # Cobertura (& compatible) coverage reader plugin
+      class Cobertura < Action
+        def initialize(args = {})
+          args.symbolize_keys!
+
+          # There must be the path to the coverage report..
+          raise 'a Cobertura action requires a path' unless args.include? :path
+
+          @path = args[:path]
+        end
+
+        def perform(log)
+          # Retrieve the Cobertura XML report
+          report = StringIO.new
+          @transport.download(report, @path ** @ctx)
+
+          # Parse the report and extract the line & branch coverage.
+          xml = Nokogiri.parse(report.string)
+          coverage = xml.xpath('//coverage')
+          line_rate = coverage.attr('line-rate').value.to_i
+          branch_rate = coverage.attr('branch-rate').value.to_i
+
+          # Coverage is given as a fraction, so convert it to a percentage.
+          #
+          # Cobertura can produce oddly specific coverage metrics, so round it
+          # to only 2 decimal points...
+          line_rate_pct = (line_rate * 100).round(2)
+          branch_rate_pct = (branch_rate * 100).round(2)
+
+          log.write "Cobertura coverage line rate is #{line_rate_pct}%, " \
+                    "branch rate is #{branch_rate_pct}%\n"
+
+          @ctx[:cobertura_line_rate] = "#{line_rate_pct}%"
+          @ctx[:cobertura_branch_rate] = "#{branch_rate_pct}%"
+
+          return [true, 0]
+        rescue StandardError => ex
+          log.write "Failed to read Cobertura coverage report: #{ex}"
+
+          return [false, 0]
+        end
+
+        # Register this plugin
+        register_plugin 'cobertura'
+      end
+    end
+  end
+end

--- a/app/cyclid/plugins/action/simplecov.rb
+++ b/app/cyclid/plugins/action/simplecov.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+# Copyright 2016, 2017 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Top level module for the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # Module for Cyclid Plugins
+    module Plugins
+      # Simplecov coverage reader plugin
+      class Simplecov < Action
+        def initialize(args = {})
+          args.symbolize_keys!
+
+          # There must be the path to the coverage report..
+          raise 'a simplecov action requires a path' unless args.include? :path
+
+          @path = args[:path]
+        end
+
+        def perform(log)
+          # Retrieve the Simplecov JSON report
+          report = StringIO.new
+          path = "#{@path ** @ctx}/coverage/coverage.json"
+          @transport.download(report, path)
+
+          # Parse the report and extract the total coverage percentage;
+          # Simplecov can produce oddly specific coverage metrics, so round it
+          # to only 2 decimal points...
+          coverage = JSON.parse(report.string)
+          covered_percent = coverage['metrics']['covered_percent'].round(2)
+
+          log.write "Simplecov coverage is #{covered_percent}%\n"
+          @ctx[:simplecov_coverage] = "#{covered_percent}%"
+
+          return [true, 0]
+        rescue StandardError => ex
+          log.write "Failed to read Simplecov coverage report: #{ex}"
+
+          return [false, 0]
+        end
+
+        # Register this plugin
+        register_plugin 'simplecov'
+      end
+    end
+  end
+end

--- a/app/cyclid/plugins/action/simplecov.rb
+++ b/app/cyclid/plugins/action/simplecov.rb
@@ -33,8 +33,7 @@ module Cyclid
         def perform(log)
           # Retrieve the Simplecov JSON report
           report = StringIO.new
-          path = "#{@path ** @ctx}/coverage/coverage.json"
-          @transport.download(report, path)
+          @transport.download(report, @path ** @ctx)
 
           # Parse the report and extract the total coverage percentage;
           # Simplecov can produce oddly specific coverage metrics, so round it

--- a/spec/plugins/action/cobertura_spec.rb
+++ b/spec/plugins/action/cobertura_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Cyclid::API::Plugins::Cobertura do
+  context 'creating a new instance' do
+    it 'creates a new instance with a path' do
+      expect{ Cyclid::API::Plugins::Cobertura.new(path: '/foo/bar') }.to_not raise_error
+    end
+
+    it 'fails if no path is given' do
+      expect{ Cyclid::API::Plugins::Cobertura.new }.to raise_error
+    end
+  end
+
+  let :transport do
+    instance_double(Cyclid::API::Plugins::Transport)
+  end
+
+  let :log do
+    instance_double(Cyclid::API::LogBuffer)
+  end
+
+  # Thanks, Jenkins!
+  #
+  # https://raw.githubusercontent.com/jenkinsci/cobertura-plugin/master/src/test/resources/hudson/plugins/cobertura/coverage-with-data.xml
+  let :valid_report do
+    '<?xml version="1.0"?>
+     <coverage line-rate="0.9" branch-rate="0.75" version="1.9" timestamp="1187350905008">
+     </coverage>'
+  end
+
+  context 'with a valid Cobertura coverage report' do
+    before :each do
+      expect(log).to receive(:write)
+    end
+
+    it 'reads the report' do
+      context = {}
+
+      cobertura = Cyclid::API::Plugins::Cobertura.new(path: '/foo/bar')
+      cobertura.prepare(transport: transport, ctx: context)
+
+      expect(transport).to receive(:download)
+        .with(instance_of(StringIO), '/foo/bar') { |io, _path| io.write(valid_report) }
+
+      expect(cobertura.perform(log)).to match_array([true, 0])
+      expect(context).to include(:cobertura_line_rate)
+      expect(context[:cobertura_line_rate]).to eq('90.0%')
+
+      expect(context).to include(:cobertura_branch_rate)
+      expect(context[:cobertura_branch_rate]).to eq('75.0%')
+    end
+  end
+
+  let :invalid_report do
+    '<?xml version="1.0"?>'
+  end
+
+  context 'with a invalid Cobertura coverage report' do
+    before :each do
+      expect(log).to receive(:write)
+    end
+
+    it 'exits with a failure' do
+      context = {}
+
+      cobertura = Cyclid::API::Plugins::Cobertura.new(path: '/foo/bar')
+      cobertura.prepare(transport: transport, ctx: context)
+
+      expect(transport).to receive(:download)
+        .with(instance_of(StringIO), '/foo/bar') { |io, _path| io.write(invalid_report) }
+
+      expect(cobertura.perform(log)).to match_array([false, 0])
+    end
+  end
+end

--- a/spec/plugins/action/simplecov_spec.rb
+++ b/spec/plugins/action/simplecov_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Cyclid::API::Plugins::Simplecov do
+  context 'creating a new instance' do
+    it 'creates a new instance with a path' do
+      expect{ Cyclid::API::Plugins::Simplecov.new(path: '/foo/bar') }.to_not raise_error
+    end
+
+    it 'fails if no path is given' do
+      expect{ Cyclid::API::Plugins::Simplecov.new }.to raise_error
+    end
+  end
+
+  let :transport do
+    instance_double(Cyclid::API::Plugins::Transport)
+  end
+
+  let :log do
+    instance_double(Cyclid::API::LogBuffer)
+  end
+
+  let :valid_report do
+    '{
+      "metrics" : {
+        "covered_lines" : 2109,
+        "covered_percent" : 86.0816326530612,
+        "covered_strength" : 7.2925306122449,
+        "total_lines" : 2450
+      }
+    }'
+  end
+
+  context 'with a valid Simplecov coverage report' do
+    before :each do
+      expect(log).to receive(:write)
+    end
+
+    it 'reads the report' do
+      context = {}
+
+      simplecov = Cyclid::API::Plugins::Simplecov.new(path: '/foo/bar')
+      simplecov.prepare(transport: transport, ctx: context)
+
+      expect(transport).to receive(:download)
+        .with(instance_of(StringIO), '/foo/bar') { |io, _path| io.write(valid_report) }
+
+      expect(simplecov.perform(log)).to match_array([true, 0])
+      expect(context).to include(:simplecov_coverage)
+      expect(context[:simplecov_coverage]).to eq('86.08%')
+    end
+  end
+
+  let :invalid_report do
+    '{}'
+  end
+
+  context 'with a invalid Simplecov coverage report' do
+    before :each do
+      expect(log).to receive(:write)
+    end
+
+    it 'exits with a failure' do
+      context = {}
+
+      simplecov = Cyclid::API::Plugins::Simplecov.new(path: '/foo/bar')
+      simplecov.prepare(transport: transport, ctx: context)
+
+      expect(transport).to receive(:download)
+        .with(instance_of(StringIO), '/foo/bar') { |io, _path| io.write(invalid_report) }
+
+      expect(simplecov.perform(log)).to match_array([false, 0])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'bundler/setup'
 require 'simplecov'
+require 'simplecov-json'
 
 SimpleCov.start do
   add_filter '/spec/'
@@ -12,5 +13,10 @@ SimpleCov.start do
   add_group 'Job', 'app/cyclid/job'
   add_group 'Plugins', 'app/cyclid/plugins'
 end
+
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::JSONFormatter
+]
 
 require 'spec_setup'


### PR DESCRIPTION
Add a Simplecov plugin which can read a Simplecov JSON report and insert the coverage rate into the Job context.
Add a Cobertura plugin which can read a Cobertura XML report and insert the coverage & branch rate into the Job context.
Add simplecov-json and configure Simplecov to generate a JSON report for ourselves, in preparation for using the coverage plugin ourselves.