### PR TITLE
Add Redhat-ish Provisioners

### DIFF
--- a/app/cyclid/plugins/builder/google.rb
+++ b/app/cyclid/plugins/builder/google.rb
@@ -144,7 +144,9 @@ module Cyclid
 
             match = image.name.match(/^#{distro}-((\d*)-(.*)-v.*$|(\d*)-v.*$)/)
             next unless match
-            next unless match[2] == release or match[3] == release
+            next unless match[2] == release or
+                        match[3] == release or
+                        match[4] == release
 
             # Found one
             Cyclid.logger.info "found image #{image.name} for #{distro}:#{release}"

--- a/app/cyclid/plugins/provisioner/centos.rb
+++ b/app/cyclid/plugins/provisioner/centos.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# Copyright 2017, 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'redhat/helpers'
+
+# Top level module for the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # Module for Cyclid Plugins
+    module Plugins
+      # CentOS provisioner
+      class Centos < Provisioner
+        def initialize
+          @quiet = true
+        end
+
+        # Prepare a CentOS based build host
+        def prepare(transport, buildhost, env = {})
+          release = buildhost[:release].to_i
+
+          Cyclid.logger.debug 'is Centos'
+          if release >= 6
+            Cyclid.logger.debug 'is >= 6'
+            prepare_redhat(transport, env)
+          else
+            Cyclid.logger.debug 'is < 5'
+            prepare_redhat_5(transport, env)
+          end
+        end
+
+        # Register this plugin
+        register_plugin 'centos'
+
+        include Helpers::Redhat
+      end
+    end
+  end
+end

--- a/app/cyclid/plugins/provisioner/fedora.rb
+++ b/app/cyclid/plugins/provisioner/fedora.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# Copyright 2017, 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'redhat/helpers'
+
+# Top level module for the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # Module for Cyclid Plugins
+    module Plugins
+      # Fedora provisioner
+      class Fedora < Provisioner
+        def initialize
+          @quiet = true
+        end
+
+        # Prepare a Fedora based build host
+        def prepare(transport, buildhost, env = {})
+          release = buildhost[:release].to_i
+
+          Cyclid.logger.debug 'is Fedora'
+          if release >= 22
+            Cyclid.logger.debug 'is >= 22'
+            prepare_fedora_dnf(transport, env)
+          else
+            Cyclid.logger.debug 'is < 22'
+            prepare_fedora_yum(transport, env)
+          end
+        end
+
+        # Register this plugin
+        register_plugin 'fedora'
+
+        include Helpers::Redhat
+      end
+    end
+  end
+end

--- a/app/cyclid/plugins/provisioner/redhat/helpers.rb
+++ b/app/cyclid/plugins/provisioner/redhat/helpers.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+# Copyright 2017, 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Top level module for the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # Module for Cyclid Plugins
+    module Plugins
+      # Module for helper methods
+      module Helpers
+        # Redhatish provisioner helper methods
+        module Redhat
+          # Insert the --quiet flag if required
+          def quiet
+            @quiet ? '-q' : ''
+          end
+
+          # Install the yum-utils package
+          def install_yum_utils(transport)
+            transport.exec 'yum install -q -y yum-utils'
+          end
+
+          # Import a signing key with RPM
+          def import_signing_key(transport, key_url)
+            transport.exec("rpm #{quiet} --import #{key_url}") \
+          end
+
+          # Install a package group with yum
+          def yum_groupinstall(transport, groups)
+            grouplist = groups.map{ |g| "\"#{g}\"" }.join(' ')
+            transport.exec "yum groupinstall #{quiet} -y #{grouplist}"
+          end
+
+          # Install a list of packages with yum
+          def yum_install(transport, packages)
+            transport.exec "yum install #{quiet} -y #{packages.join(' ')}"
+          end
+
+          # Add a repository with yum-config-manager
+          def yum_add_repo(transport, url)
+            transport.exec("yum-config-manager #{quiet} --add-repo #{url}")
+          end
+
+          # Use DNF to configure & install Fedora
+          def prepare_fedora_dnf(transport, env)
+            Cyclid.logger.debug 'using DNF'
+
+            if env.key? :repos
+              # We need the config-manager plugin
+              transport.exec("dnf install #{quiet} -y 'dnf-command(config-manager)'")
+
+              env[:repos].each do |repo|
+                next unless repo.key? :url
+
+                # If there's a key, install it
+                import_signing_key(transport, repo[:key_url]) \
+                  if repo.key? :key_url
+
+                if repo[:url] =~ /\.rpm$/
+                  # If the URL is an RPM just install it
+                  transport.exec("dnf install #{quiet} -y #{repo[:url]}")
+                else
+                  # Not an RPM? Let's hope it's a repo file
+                  transport.exec("dnf config-manager #{quiet} --add-repo #{repo[:url]}")
+                end
+              end
+            end
+
+            if env.key? :groups
+              groups = env[:groups].map{ |g| "\"#{g}\"" }.join(' ')
+              transport.exec "dnf groups install #{quiet} -y #{groups}"
+            end
+
+            transport.exec "dnf install #{quiet} -y #{env[:packages].join(' ')}" \
+              if env.key? :packages
+          end
+
+          # Use YUM to configure & install Fedora
+          def prepare_fedora_yum(transport, env)
+            Cyclid.logger.debug 'using YUM'
+
+            if env.key? :repos
+              # We'll need yum-utils for yum-config-manager
+              install_yum_utils(transport)
+
+              env[:repos].each do |repo|
+                next unless repo.key? :url
+
+                # If there's a key, install it
+                import_signing_key(transport, repo[:key_url]) \
+                  if repo.key? :key_url
+
+                if repo[:url] =~ /\.rpm$/
+                  # If the URL is an RPM just install it
+                  transport.exec("yum install #{quiet} -y --nogpgcheck #{repo[:url]}")
+                else
+                  # Not an RPM? Let's hope it's a repo file
+                  yum_add_repo(transport, repo[:url])
+                end
+              end
+            end
+
+            yum_groupinstall(transport, env[:groups]) \
+              if env.key? :groups
+
+            yum_install(transport, env[:packages]) \
+              if env.key? :packages
+          end
+
+          # Use YUM to configure & install a Redhat-like (RHEL, CentOS etc.)
+          def prepare_redhat(transport, env)
+            Cyclid.logger.debug 'using YUM'
+
+            if env.key? :repos
+              # We'll need yum-utils for yum-config-manager
+              install_yum_utils(transport)
+
+              env[:repos].each do |repo|
+                next unless repo.key? :url
+
+                # If there's a key, install it
+                import_signing_key(transport, repo[:key_url]) \
+                  if repo.key? :key_url
+
+                if repo[:url] =~ /\.rpm$/
+                  # If the URL is an RPM just install it
+                  transport.exec("yum localinstall #{quiet} -y --nogpgcheck #{repo[:url]}")
+                else
+                  # Not an RPM? Let's hope it's a repo file
+                  yum_add_repo(transport, repo[:url])
+                end
+              end
+            end
+
+            yum_groupinstall(transport, env[:groups]) \
+              if env.key? :groups
+
+            yum_install(transport, env[:packages]) \
+              if env.key? :packages
+          end
+
+          # Use YUM & RPM to configure & install a Redhat-like (RHEL, CentOS etc.)
+          def prepare_redhat_5(transport, env)
+            if env.key? :repos
+              env[:repos].each do |repo|
+                next unless repo.key? :url
+
+                # If there's a key, install it
+                import_signing_key(transport, repo[:key_url]) \
+                  if repo.key? :key_url
+
+                # Assume the URL is an RPM
+                transport.exec("rpm -U #{quiet} #{repo[:url]}")
+              end
+            end
+
+            yum_groupinstall(transport, env[:groups]) \
+              if env.key? :groups
+
+            yum_install(transport, env[:packages]) \
+              if env.key? :packages
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/cyclid/plugins/provisioner/rhel.rb
+++ b/app/cyclid/plugins/provisioner/rhel.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# Copyright 2017, 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'redhat/helpers'
+
+# Top level module for the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # Module for Cyclid Plugins
+    module Plugins
+      # RHEL provisioner
+      class RHEL < Provisioner
+        def initialize
+          @quiet = true
+        end
+
+        # Prepare a RHEL based build host
+        def prepare(transport, buildhost, env = {})
+          release = buildhost[:release].to_i
+
+          Cyclid.logger.debug 'is RHEL'
+          if release >= 6
+            Cyclid.logger.debug 'is >= 6'
+            prepare_redhat(transport, env)
+          else
+            Cyclid.logger.debug 'is < 5'
+            prepare_redhat_5(transport, env)
+          end
+        end
+
+        # Register this plugin
+        register_plugin 'rhel'
+
+        include Helpers::Redhat
+      end
+    end
+  end
+end

--- a/spec/plugins/provisioner/centos_spec.rb
+++ b/spec/plugins/provisioner/centos_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Cyclid::API::Plugins::Centos do
+  context 'creating a new instance' do
+    it 'should create a new instance' do
+      expect{ Cyclid::API::Plugins::Centos.new }.to_not raise_error
+    end
+  end
+
+  let :transport do
+    instance_double(Cyclid::API::Plugins::Transport)
+  end
+
+  context 'with a CentOS 5 build host' do
+    let :buildhost do
+      Cyclid::API::Plugins::BuildHost.new(hostname: 'test.example.com',
+                                          release: '5')
+    end
+
+    context 'with an empty environment & packages list' do
+      it 'should prepare a host' do
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost) }.to_not raise_error
+      end
+    end
+
+    context 'with additional repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.rpm' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('rpm -U -q http://example.com/repository.rpm')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with package groups' do
+      let :env do
+        { groups: %w(group1 group2) }
+      end
+
+      it 'should install the package groups' do
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional packages' do
+      let :env do
+        { packages: %w(package1 package2) }
+      end
+
+      it 'should install the packages' do
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+  end
+
+  context 'with a CentOS 6 build host' do
+    let :buildhost do
+      Cyclid::API::Plugins::BuildHost.new(hostname: 'test.example.com',
+                                          release: '6')
+    end
+
+    context 'with an empty environment & packages list' do
+      it 'should prepare a host' do
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost) }.to_not raise_error
+      end
+    end
+
+    context 'with additional HTTP repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.repo' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional RPM repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.rpm' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+        expect(transport).to receive(:exec).with('yum localinstall -q -y --nogpgcheck http://example.com/repository.rpm')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with package groups' do
+      let :env do
+        { groups: %w(group1 group2) }
+      end
+
+      it 'should install the package groups' do
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional packages' do
+      let :env do
+        { packages: %w(package1 package2) }
+      end
+
+      it 'should install the packages' do
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/plugins/provisioner/fedora_spec.rb
+++ b/spec/plugins/provisioner/fedora_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Cyclid::API::Plugins::Fedora do
+  context 'creating a new instance' do
+    it 'should create a new instance' do
+      expect{ Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+    end
+  end
+
+  let :transport do
+    instance_double(Cyclid::API::Plugins::Transport)
+  end
+
+  context 'with a Fedora 21 build host' do
+    let :buildhost do
+      Cyclid::API::Plugins::BuildHost.new(hostname: 'test.example.com',
+                                          release: '21')
+    end
+
+    context 'with an empty environment & packages list' do
+      it 'should prepare a host' do
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost) }.to_not raise_error
+      end
+    end
+
+    context 'with additional HTTP repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.repo',
+                    key_url: 'http://example.com/repository.key' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
+        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional RPM repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.rpm',
+                    key_url: 'http://example.com/repository.key' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
+        expect(transport).to receive(:exec).with('yum install -q -y --nogpgcheck http://example.com/repository.rpm')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with package groups' do
+      let :env do
+        { groups: %w(group1 group2) }
+      end
+
+      it 'should install the package groups' do
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional packages' do
+      let :env do
+        { packages: %w(package1 package2) }
+      end
+
+      it 'should install the packages' do
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+  end
+
+  context 'with a Fedora 22 build host' do
+    let :buildhost do
+      Cyclid::API::Plugins::BuildHost.new(hostname: 'test.example.com',
+                                          release: '22')
+    end
+
+    context 'with an empty environment & packages list' do
+      it 'should prepare a host' do
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost) }.to_not raise_error
+      end
+    end
+
+    context 'with additional HTTP repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.repo',
+                    key_url: 'http://example.com/repository.key' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with("dnf install -q -y 'dnf-command(config-manager)'")
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
+        expect(transport).to receive(:exec).with('dnf config-manager -q --add-repo http://example.com/repository.repo')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional RPM repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.rpm',
+                    key_url: 'http://example.com/repository.key' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with("dnf install -q -y 'dnf-command(config-manager)'")
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
+        expect(transport).to receive(:exec).with('dnf install -q -y http://example.com/repository.rpm')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with package groups' do
+      let :env do
+        { groups: %w(group1 group2) }
+      end
+
+      it 'should install the package groups' do
+        expect(transport).to receive(:exec).with('dnf groups install -q -y "group1" "group2"')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional packages' do
+      let :env do
+        { packages: %w(package1 package2) }
+      end
+
+      it 'should install the packages' do
+        expect(transport).to receive(:exec).with('dnf install -q -y package1 package2')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/plugins/provisioner/redhat/helpers_spec.rb
+++ b/spec/plugins/provisioner/redhat/helpers_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Cyclid::API::Plugins::Helpers::Redhat do
+  let :dummy_class do
+    Class.new { extend Cyclid::API::Plugins::Helpers::Redhat }
+  end
+
+  let :transport do
+    instance_double(Cyclid::API::Plugins::Transport)
+  end
+
+  describe '#install_yum_utils' do
+    it 'uses YUM to install the yum-utils package' do
+      expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+      expect{ dummy_class.install_yum_utils(transport) }.to_not raise_error
+    end
+  end
+
+  describe '#import_signing_key' do
+    let :key do
+      'http://example.com/repository.key'
+    end
+
+    it 'uses RPM to install the signing key' do
+      expect(transport).to receive(:exec).with("rpm  --import #{key}")
+      expect{ dummy_class.import_signing_key(transport, key) }.to_not raise_error
+    end
+  end
+
+  describe '#yum_groupinstall' do
+    let :groups do
+      %w(group1 group2)
+    end
+
+    it 'uses YUM to install the list of groups' do
+      expect(transport).to receive(:exec).with('yum groupinstall  -y "group1" "group2"')
+      expect{ dummy_class.yum_groupinstall(transport, groups) }.to_not raise_error
+    end
+  end
+
+  describe '#yum_install' do
+    let :packages do
+      %w(package1 package2)
+    end
+
+    it 'uses YUM to install the list of packages' do
+      expect(transport).to receive(:exec).with("yum install  -y #{packages.join(' ')}")
+      expect{ dummy_class.yum_install(transport, packages) }.to_not raise_error
+    end
+  end
+
+  describe '#yum_add_repo' do
+    let :url do
+      'http://example.com/repository.repo'
+    end
+
+    it 'uses YUM to add the repository' do
+      expect(transport).to receive(:exec).with("yum-config-manager  --add-repo #{url}")
+      expect{ dummy_class.yum_add_repo(transport, url) }.to_not raise_error
+    end
+  end
+end

--- a/spec/plugins/provisioner/rhel_spec.rb
+++ b/spec/plugins/provisioner/rhel_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Cyclid::API::Plugins::RHEL do
+  context 'creating a new instance' do
+    it 'should create a new instance' do
+      expect{ Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+    end
+  end
+
+  let :transport do
+    instance_double(Cyclid::API::Plugins::Transport)
+  end
+
+  context 'with a RHEL 5 build host' do
+    let :buildhost do
+      Cyclid::API::Plugins::BuildHost.new(hostname: 'test.example.com',
+                                          release: '5')
+    end
+
+    context 'with an empty environment & packages list' do
+      it 'should prepare a host' do
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost) }.to_not raise_error
+      end
+    end
+
+    context 'with additional repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.rpm' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('rpm -U -q http://example.com/repository.rpm')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with package groups' do
+      let :env do
+        { groups: %w(group1 group2) }
+      end
+
+      it 'should install the package groups' do
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional packages' do
+      let :env do
+        { packages: %w(package1 package2) }
+      end
+
+      it 'should install the packages' do
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+  end
+
+  context 'with a RHEL 6 build host' do
+    let :buildhost do
+      Cyclid::API::Plugins::BuildHost.new(hostname: 'test.example.com',
+                                          release: '6')
+    end
+
+    context 'with an empty environment & packages list' do
+      it 'should prepare a host' do
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost) }.to_not raise_error
+      end
+    end
+
+    context 'with additional HTTP repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.repo' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional RPM repositories' do
+      let :env do
+        { repos: [{ url: 'http://example.com/repository.rpm' }] }
+      end
+
+      it 'should configure the host to use the repositories' do
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+        expect(transport).to receive(:exec).with('yum localinstall -q -y --nogpgcheck http://example.com/repository.rpm')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with package groups' do
+      let :env do
+        { groups: %w(group1 group2) }
+      end
+
+      it 'should install the package groups' do
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+
+    context 'with additional packages' do
+      let :env do
+        { packages: %w(package1 package2) }
+      end
+
+      it 'should install the packages' do
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+
+        provisioner = nil
+        expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
+        expect{ provisioner.prepare(transport, buildhost, env) }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Provisioners for Fedora, CentOS & RHEL.
The Fedora plugin supports Fedora < 22 with YUM and >= 22 with DNF.
The CentOS provisioner supports 7, 6 & < 6
The RHEL provisioner supports 7, < 7
Provisioners can add both .repo (Not CentOS/RHEL < 6) & .rpm style packages, and signing keys.
Install individual packages, or package groups if a list of groups is specified.