### PR TITLE
Ensure all AR connections are checked in

### DIFF
--- a/app/cyclid/plugins/dispatcher/local.rb
+++ b/app/cyclid/plugins/dispatcher/local.rb
@@ -159,6 +159,8 @@ module Cyclid
             notifier.completion(success)
 
             return success
+          ensure
+            ::ActiveRecord::Base.clear_active_connections!
           end
         end
       end


### PR DESCRIPTION
The Sidekiq worker uses ActiveRecord models (the JobRecord), and we must
ensure that all checked out connections are checked back in when the worker
exits by calling clear_active_connections!