### PR TITLE
Add the fail_if modifier

### DIFF
--- a/app/cyclid/job/evaluator.rb
+++ b/app/cyclid/job/evaluator.rb
@@ -23,12 +23,13 @@ module Cyclid
       class EvalException < RuntimeError
       end
 
-      # Evalute an expression for "only_if" & "not_if"
+      # Evalute an expression for "only_if", "not_if" & "fail_if"
       class Evaluator
         class << self
           def only_if(statement, vars)
             evaluate(statement, vars)
           end
+          alias fail_if only_if
 
           def not_if(statement, vars)
             not evaluate(statement, vars) # rubocop:disable Style/Not

--- a/app/cyclid/job/job.rb
+++ b/app/cyclid/job/job.rb
@@ -144,7 +144,7 @@ module Cyclid
                             end
             stage_view.on_success = success_stage
 
-            # Now set the on_failure failure
+            # Now set the on_failure handler
             stage_failure = { stage: job_stage[:on_failure] }
             job_sequence << stage_failure \
               unless job_stage[:on_failure].nil? or \
@@ -154,6 +154,7 @@ module Cyclid
             # Merge in any modifiers
             stage_view.only_if = job_stage[:only_if]
             stage_view.not_if = job_stage[:not_if]
+            stage_view.fail_if = job_stage[:fail_if]
 
             # Store the modified StageView
             stages[stage_view.name.to_sym] = stage_view

--- a/app/cyclid/job/runner.rb
+++ b/app/cyclid/job/runner.rb
@@ -156,6 +156,15 @@ module Cyclid
               # rubocop:enable Style/MultilineTernaryOperator
             end
 
+            # Fail the stage if fail_if applies
+            if stage.fail_if && Evaluator.fail_if(stage.fail_if, @ctx)
+              @notifier.write "Stage #{stage.name} v#{stage.version} failed: #{stage.fail_if}\n"
+
+              success = false
+
+              Cyclid.logger.info "stage failed due to #{stage.fail_if}"
+            end
+
             # Decide which stage to run next depending on the outcome of this
             # one
             if success

--- a/app/cyclid/job/stage.rb
+++ b/app/cyclid/job/stage.rb
@@ -25,7 +25,7 @@ module Cyclid
       # the database object.
       class StageView
         attr_reader :name, :version, :steps
-        attr_accessor :on_success, :on_failure, :only_if, :not_if
+        attr_accessor :on_success, :on_failure, :only_if, :not_if, :fail_if
 
         def initialize(arg)
           if arg.is_a? Cyclid::API::Stage

--- a/spec/job/runner_spec.rb
+++ b/spec/job/runner_spec.rb
@@ -209,9 +209,51 @@ describe Cyclid::API::Job::Runner do
       expect{ job.run }.to_not raise_error
     end
 
-    it 'runs a job when the expression evaluates as false' do
+    it 'the stage succeeds when the expression evaluates as false' do
       stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
       sequence = [{ stage: 'test', not_if: '1 eq 0' }]
+      job_def = { name: 'test',
+                  environment: {},
+                  sources: [],
+                  stages: stages,
+                  sequence: sequence }
+
+      job_view = nil
+      expect{ job_view = Cyclid::API::Job::JobView.new(job_def, {}, @org) }.to_not raise_error
+
+      job_json = nil
+      expect{ job_json = job_view.to_hash.to_json }.to_not raise_error
+
+      job = nil
+      expect{ job = Cyclid::API::Job::Runner.new(5, job_json, @notifier) }.to_not raise_error
+      expect{ job.run }.to_not raise_error
+    end
+  end
+
+  context 'with a fail_if modifier' do
+    it 'the stage fails when the expression evaluates as true' do
+      stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
+      sequence = [{ stage: 'test', fail_if: '1 eq 1' }]
+      job_def = { name: 'test',
+                  environment: {},
+                  sources: [],
+                  stages: stages,
+                  sequence: sequence }
+
+      job_view = nil
+      expect{ job_view = Cyclid::API::Job::JobView.new(job_def, {}, @org) }.to_not raise_error
+
+      job_json = nil
+      expect{ job_json = job_view.to_hash.to_json }.to_not raise_error
+
+      job = nil
+      expect{ job = Cyclid::API::Job::Runner.new(5, job_json, @notifier) }.to_not raise_error
+      expect{ job.run }.to_not raise_error
+    end
+
+    it 'runs a job when the expression evaluates as false' do
+      stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
+      sequence = [{ stage: 'test', fail_if: '1 eq 0' }]
       job_def = { name: 'test',
                   environment: {},
                   sources: [],


### PR DESCRIPTION
The fail_if modifier is evaluated after the stage has run, and will force the
stage to be failed if the condition evaulates as true: this could be used to
E.g. check if test coverage is acceptable after the coverage plugin has run,
and fail the stage if the result is not acceptable.