### PR TITLE
GitHub bug fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ PATH
 PATH
   remote: .
   specs:
-    cyclid (0.3.2)
+    cyclid (0.3.3)
       activerecord (~> 4.2)
       addressable (< 2.4)
       bcrypt (~> 3.1)

--- a/app/cyclid/plugins/api/github/helpers.rb
+++ b/app/cyclid/plugins/api/github/helpers.rb
@@ -131,8 +131,7 @@ module Cyclid
               case type
               when 'json'
                 Oj.load(Base64.decode64(blob.content))
-              when 'yml'
-              when 'yaml'
+              when 'yml', 'yaml'
                 YAML.load(Base64.decode64(blob.content))
               end
             end

--- a/app/cyclid/plugins/api/github/pull_request.rb
+++ b/app/cyclid/plugins/api/github/pull_request.rb
@@ -157,7 +157,7 @@ module Cyclid
               end
 
               # If we didn't update an existing source definition, insert the new one
-              normalized << new unless updated
+              normalized << new_source unless updated
 
               normalized.compact
             end

--- a/lib/cyclid/version.rb
+++ b/lib/cyclid/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Cyclid
   module Api
-    VERSION = '0.3.2'
+    VERSION = '0.3.3'
   end
 end


### PR DESCRIPTION
Fix a few obvious bugs in the Github API plugin.
While we're here bump the version to 0.3.3 in preparation for a release.