### PR TITLE
Add plugin metadata

### DIFF
--- a/app/cyclid/controllers/plugins.rb
+++ b/app/cyclid/controllers/plugins.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+# Copyright 2017 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Top level module for all of the core Cyclid code.
+module Cyclid
+  # Module for the Cyclid API
+  module API
+    # API endpoints for plugins information
+    # @api REST
+    class PluginController < ControllerBase
+      include Errors::HTTPErrors
+
+      # Return plugin metadata
+      get '/plugins' do
+        authorized_for!(params[:name], Operations::READ)
+
+        metadata = []
+        Cyclid.plugins.all.each do |plugin|
+          metadata << plugin.metadata
+        end
+
+        return metadata.to_json
+      end
+    end
+
+    # Register this controller
+    Cyclid.controllers << PluginController
+  end
+end

--- a/app/cyclid/plugins.rb
+++ b/app/cyclid/plugins.rb
@@ -40,6 +40,36 @@ module Cyclid
             Cyclid.plugins.register(self)
           end
 
+          # Return the plugin version
+          def version
+            @version || '1.0.0'
+          end
+
+          # Return the plugin author
+          def author
+            @author || 'Unknown'
+          end
+
+          # Return the plugin license
+          def license
+            @license || 'Unknown'
+          end
+
+          # Return a URL to the plugin homepage
+          def homepage
+            @homepage || 'https://cyclid.io'
+          end
+
+          # Return plugin metadata
+          def metadata
+            { name: @name,
+              type: human_name,
+              version: version,
+              author: author,
+              license: license,
+              homepage: homepage }
+          end
+
           # Does this plugin support configuration data?
           def config?
             false

--- a/app/cyclid/plugins/action/cobertura.rb
+++ b/app/cyclid/plugins/action/cobertura.rb
@@ -63,6 +63,14 @@ module Cyclid
           return [false, 0]
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'cobertura'
       end

--- a/app/cyclid/plugins/action/command.rb
+++ b/app/cyclid/plugins/action/command.rb
@@ -81,6 +81,14 @@ module Cyclid
           [success, @transport.exit_code]
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'command'
       end

--- a/app/cyclid/plugins/action/email.rb
+++ b/app/cyclid/plugins/action/email.rb
@@ -113,6 +113,14 @@ module Cyclid
           [success, 0]
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'email'
 

--- a/app/cyclid/plugins/action/log.rb
+++ b/app/cyclid/plugins/action/log.rb
@@ -36,6 +36,14 @@ module Cyclid
           true
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'log'
       end

--- a/app/cyclid/plugins/action/script.rb
+++ b/app/cyclid/plugins/action/script.rb
@@ -82,6 +82,14 @@ module Cyclid
           [success, @transport.exit_code]
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'script'
       end

--- a/app/cyclid/plugins/action/simplecov.rb
+++ b/app/cyclid/plugins/action/simplecov.rb
@@ -51,6 +51,14 @@ module Cyclid
           return [false, 0]
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'simplecov'
       end

--- a/app/cyclid/plugins/action/slack.rb
+++ b/app/cyclid/plugins/action/slack.rb
@@ -94,6 +94,14 @@ module Cyclid
           [success, rc]
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'slack'
 

--- a/app/cyclid/plugins/api/github.rb
+++ b/app/cyclid/plugins/api/github.rb
@@ -33,6 +33,14 @@ module Cyclid
             return ApiExtension::Controller.new(ApiExtension::GithubMethods, routes)
           end
 
+          # Plugin metadata
+          def metadata
+            super.merge!(version: Cyclid::Api::VERSION,
+                         license: 'Apache-2.0',
+                         author: 'Liqwyd Ltd.',
+                         homepage: 'http://docs.cyclid.io')
+          end
+
           # This plugin has configuration data
           def config?
             true

--- a/app/cyclid/plugins/builder/docker.rb
+++ b/app/cyclid/plugins/builder/docker.rb
@@ -84,6 +84,14 @@ module Cyclid
           container.delete(force: true)
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'docker'
 

--- a/app/cyclid/plugins/builder/google.rb
+++ b/app/cyclid/plugins/builder/google.rb
@@ -92,6 +92,14 @@ module Cyclid
           raise 'failed to destroy instance' unless instance.destroy
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'google'
 

--- a/app/cyclid/plugins/dispatcher/local.rb
+++ b/app/cyclid/plugins/dispatcher/local.rb
@@ -70,6 +70,14 @@ module Cyclid
           end
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'local'
       end

--- a/app/cyclid/plugins/provisioner/centos.rb
+++ b/app/cyclid/plugins/provisioner/centos.rb
@@ -41,6 +41,14 @@ module Cyclid
           end
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'centos'
 

--- a/app/cyclid/plugins/provisioner/debian.rb
+++ b/app/cyclid/plugins/provisioner/debian.rb
@@ -59,6 +59,14 @@ module Cyclid
           raise
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         private
 
         def add_http_repository(transport, url, repo, buildhost)

--- a/app/cyclid/plugins/provisioner/fedora.rb
+++ b/app/cyclid/plugins/provisioner/fedora.rb
@@ -41,6 +41,14 @@ module Cyclid
           end
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'fedora'
 

--- a/app/cyclid/plugins/provisioner/rhel.rb
+++ b/app/cyclid/plugins/provisioner/rhel.rb
@@ -41,6 +41,14 @@ module Cyclid
           end
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'rhel'
 

--- a/app/cyclid/plugins/provisioner/ubuntu.rb
+++ b/app/cyclid/plugins/provisioner/ubuntu.rb
@@ -65,6 +65,14 @@ module Cyclid
           raise
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         private
 
         def add_ppa_repository(transport, url)

--- a/app/cyclid/plugins/source/git.rb
+++ b/app/cyclid/plugins/source/git.rb
@@ -61,6 +61,14 @@ module Cyclid
           return true
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         # Register this plugin
         register_plugin 'git'
 

--- a/app/cyclid/plugins/transport/dockerapi.rb
+++ b/app/cyclid/plugins/transport/dockerapi.rb
@@ -70,6 +70,14 @@ module Cyclid
           io.write(result)
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         register_plugin('dockerapi')
 
         private

--- a/app/cyclid/plugins/transport/ssh.rb
+++ b/app/cyclid/plugins/transport/ssh.rb
@@ -125,6 +125,14 @@ module Cyclid
           @session.close
         end
 
+        # Plugin metadata
+        def self.metadata
+          super.merge!(version: Cyclid::Api::VERSION,
+                       license: 'Apache-2.0',
+                       author: 'Liqwyd Ltd.',
+                       homepage: 'http://docs.cyclid.io')
+        end
+
         private
 
         def build_command(cmd, path = nil, env = {})


### PR DESCRIPTION
Add the /plugins endpoint to retrieve plugin metadata.
Add the #metdata method to plugins that returns useful information about every plugin.