### PR TITLE
Improve sudo use

### DIFF
--- a/app/cyclid/plugins/action/command.rb
+++ b/app/cyclid/plugins/action/command.rb
@@ -71,7 +71,7 @@ module Cyclid
             path = path ** @ctx unless path.nil?
 
             # Run the command
-            success = @transport.exec(cmd_args, path)
+            success = @transport.exec(cmd_args, path: path)
           rescue KeyError => ex
             # Interpolation failed
             log.write "#{ex.message}\n"

--- a/app/cyclid/plugins/provisioner/debian.rb
+++ b/app/cyclid/plugins/provisioner/debian.rb
@@ -26,7 +26,7 @@ module Cyclid
           transport.export_env('DEBIAN_FRONTEND' => 'noninteractive')
 
           # Build hosts may require an update before anything can be installed
-          success = transport.exec 'apt-get update -qq'
+          success = transport.exec('apt-get update -qq', sudo: true)
           raise 'failed to update repositories' unless success
 
           if env.key? :repos
@@ -44,13 +44,15 @@ module Cyclid
             end
 
             # We must update again to cache the new repositories
-            success = transport.exec 'apt-get update -q'
+            success = transport.exec('apt-get update -q', sudo: true)
             raise 'failed to update repositories' unless success
           end
 
           if env.key? :packages
-            success = transport.exec \
-              "apt-get install -q -y #{env[:packages].join(' ')}" \
+            success = transport.exec( \
+              "apt-get install -q -y #{env[:packages].join(' ')}", \
+              sudo: true
+            )
 
             raise "failed to install packages #{env[:packages].join(' ')}" unless success
           end
@@ -78,8 +80,10 @@ module Cyclid
           components = repo[:components]
           fragment = "deb #{url} #{release} #{components}"
 
-          success = transport.exec \
-            "sh -c \"echo '#{fragment}' | tee -a /etc/apt/sources.list.d/cyclid.list\""
+          success = transport.exec( \
+            "sh -c \"echo '#{fragment}' | tee -a /etc/apt/sources.list.d/cyclid.list\"", \
+            sudo: true
+          )
           raise "failed to add repository #{url}" unless success
 
           return unless repo.key? :key_id
@@ -87,12 +91,16 @@ module Cyclid
           # Import the signing key
           key_id = repo[:key_id]
 
-          success = transport.exec \
-            "gpg --keyserver keyserver.ubuntu.com --recv-keys #{key_id}"
+          success = transport.exec( \
+            "gpg --keyserver keyserver.ubuntu.com --recv-keys #{key_id}", \
+            sudo: true
+          )
           raise "failed to import key #{key_id}" unless success
 
-          success = transport.exec \
-            "sh -c 'gpg -a --export #{key_id} | apt-key add -'"
+          success = transport.exec( \
+            "sh -c 'gpg -a --export #{key_id} | apt-key add -'", \
+            sudo: true
+          )
           raise "failed to add repository key #{key_id}" unless success
         end
 

--- a/app/cyclid/plugins/provisioner/redhat/helpers.rb
+++ b/app/cyclid/plugins/provisioner/redhat/helpers.rb
@@ -30,28 +30,28 @@ module Cyclid
 
           # Install the yum-utils package
           def install_yum_utils(transport)
-            transport.exec 'yum install -q -y yum-utils'
+            transport.exec('yum install -q -y yum-utils', sudo: true)
           end
 
           # Import a signing key with RPM
           def import_signing_key(transport, key_url)
-            transport.exec("rpm #{quiet} --import #{key_url}") \
+            transport.exec("rpm #{quiet} --import #{key_url}", sudo: true)
           end
 
           # Install a package group with yum
           def yum_groupinstall(transport, groups)
             grouplist = groups.map{ |g| "\"#{g}\"" }.join(' ')
-            transport.exec "yum groupinstall #{quiet} -y #{grouplist}"
+            transport.exec("yum groupinstall #{quiet} -y #{grouplist}", sudo: true)
           end
 
           # Install a list of packages with yum
           def yum_install(transport, packages)
-            transport.exec "yum install #{quiet} -y #{packages.join(' ')}"
+            transport.exec("yum install #{quiet} -y #{packages.join(' ')}", sudo: true)
           end
 
           # Add a repository with yum-config-manager
           def yum_add_repo(transport, url)
-            transport.exec("yum-config-manager #{quiet} --add-repo #{url}")
+            transport.exec("yum-config-manager #{quiet} --add-repo #{url}", sudo: true)
           end
 
           # Use DNF to configure & install Fedora
@@ -60,7 +60,7 @@ module Cyclid
 
             if env.key? :repos
               # We need the config-manager plugin
-              transport.exec("dnf install #{quiet} -y 'dnf-command(config-manager)'")
+              transport.exec("dnf install #{quiet} -y 'dnf-command(config-manager)'", sudo: true)
 
               env[:repos].each do |repo|
                 next unless repo.key? :url
@@ -71,20 +71,20 @@ module Cyclid
 
                 if repo[:url] =~ /\.rpm$/
                   # If the URL is an RPM just install it
-                  transport.exec("dnf install #{quiet} -y #{repo[:url]}")
+                  transport.exec("dnf install #{quiet} -y #{repo[:url]}", sudo: true)
                 else
                   # Not an RPM? Let's hope it's a repo file
-                  transport.exec("dnf config-manager #{quiet} --add-repo #{repo[:url]}")
+                  transport.exec("dnf config-manager #{quiet} --add-repo #{repo[:url]}", sudo: true)
                 end
               end
             end
 
             if env.key? :groups
               groups = env[:groups].map{ |g| "\"#{g}\"" }.join(' ')
-              transport.exec "dnf groups install #{quiet} -y #{groups}"
+              transport.exec("dnf groups install #{quiet} -y #{groups}", sudo: true)
             end
 
-            transport.exec "dnf install #{quiet} -y #{env[:packages].join(' ')}" \
+            transport.exec("dnf install #{quiet} -y #{env[:packages].join(' ')}", sudo: true) \
               if env.key? :packages
           end
 
@@ -105,7 +105,7 @@ module Cyclid
 
                 if repo[:url] =~ /\.rpm$/
                   # If the URL is an RPM just install it
-                  transport.exec("yum install #{quiet} -y --nogpgcheck #{repo[:url]}")
+                  transport.exec("yum install #{quiet} -y --nogpgcheck #{repo[:url]}", sudo: true)
                 else
                   # Not an RPM? Let's hope it's a repo file
                   yum_add_repo(transport, repo[:url])
@@ -137,7 +137,8 @@ module Cyclid
 
                 if repo[:url] =~ /\.rpm$/
                   # If the URL is an RPM just install it
-                  transport.exec("yum localinstall #{quiet} -y --nogpgcheck #{repo[:url]}")
+                  transport.exec("yum localinstall #{quiet} -y --nogpgcheck #{repo[:url]}", \
+                                 sudo: true)
                 else
                   # Not an RPM? Let's hope it's a repo file
                   yum_add_repo(transport, repo[:url])
@@ -163,7 +164,7 @@ module Cyclid
                   if repo.key? :key_url
 
                 # Assume the URL is an RPM
-                transport.exec("rpm -U #{quiet} #{repo[:url]}")
+                transport.exec("rpm -U #{quiet} #{repo[:url]}", sudo: true)
               end
             end
 

--- a/app/cyclid/plugins/provisioner/ubuntu.rb
+++ b/app/cyclid/plugins/provisioner/ubuntu.rb
@@ -26,12 +26,12 @@ module Cyclid
           transport.export_env('DEBIAN_FRONTEND' => 'noninteractive')
 
           # Build hosts may require an update before anything can be installed
-          success = transport.exec 'apt-get update -qq'
+          success = transport.exec('apt-get update -qq', sudo: true)
           raise 'failed to update repositories' unless success
 
           if env.key? :repos
             # Ensure apt-add-repository is available
-            transport.exec 'apt-get install -qq -y software-properties-common'
+            transport.exec('apt-get install -qq -y software-properties-common', sudo: true)
 
             env[:repos].each do |repo|
               next unless repo.key? :url
@@ -50,13 +50,15 @@ module Cyclid
             end
 
             # We must update again to cache the new repositories
-            success = transport.exec 'apt-get update -q'
+            success = transport.exec('apt-get update -q', sudo: true)
             raise 'failed to update repositories' unless success
           end
 
           if env.key? :packages
-            success = transport.exec \
-              "apt-get install -q -y #{env[:packages].join(' ')}" \
+            success = transport.exec( \
+              "apt-get install -q -y #{env[:packages].join(' ')}", \
+              sudo: true
+            )
 
             raise "failed to install packages #{env[:packages].join(' ')}" unless success
           end
@@ -76,7 +78,7 @@ module Cyclid
         private
 
         def add_ppa_repository(transport, url)
-          success = transport.exec "apt-add-repository -y #{url}"
+          success = transport.exec("apt-add-repository -y #{url}", sudo: true)
           raise "failed to add repository #{url}" unless success
         end
 
@@ -89,8 +91,10 @@ module Cyclid
           components = repo[:components]
           fragment = "deb #{url} #{release} #{components}"
 
-          success = transport.exec \
-            "sh -c \"echo '#{fragment}' | tee -a /etc/apt/sources.list.d/cyclid.list\""
+          success = transport.exec( \
+            "sh -c \"echo '#{fragment}' | tee -a /etc/apt/sources.list.d/cyclid.list\"", \
+            sudo: true
+          )
           raise "failed to add repository #{url}" unless success
 
           return unless repo.key? :key_id
@@ -98,12 +102,16 @@ module Cyclid
           # Import the signing key
           key_id = repo[:key_id]
 
-          success = transport.exec \
-            "gpg --keyserver keyserver.ubuntu.com --recv-keys #{key_id}"
+          success = transport.exec( \
+            "gpg --keyserver keyserver.ubuntu.com --recv-keys #{key_id}", \
+            sudo: true
+          )
           raise "failed to import key #{key_id}" unless success
 
-          success = transport.exec \
-            "sh -c 'gpg -a --export #{key_id} | apt-key add -'"
+          success = transport.exec( \
+            "sh -c 'gpg -a --export #{key_id} | apt-key add -'", \
+            sudo: true
+          )
           raise "failed to add repository key #{key_id}" unless success
         end
 

--- a/app/cyclid/plugins/source/git.rb
+++ b/app/cyclid/plugins/source/git.rb
@@ -40,7 +40,7 @@ module Cyclid
             # username
             url.user = source[:token] if source.key? :token
 
-            success = transport.exec("git clone #{url}", ctx[:workspace])
+            success = transport.exec("git clone #{url}", path: ctx[:workspace])
             return false unless success
 
             # If a branch was given, check it out
@@ -51,10 +51,10 @@ module Cyclid
             match = url.path.match(%r{^.*\/([^\.]*)})
             source_dir = "#{ctx[:workspace]}/#{match[1]}"
 
-            success = transport.exec("git fetch origin #{branch}:#{branch}", source_dir)
+            success = transport.exec("git fetch origin #{branch}:#{branch}", path: source_dir)
             return false unless success
 
-            success = transport.exec("git checkout #{branch}", source_dir)
+            success = transport.exec("git checkout #{branch}", path: source_dir)
             return false unless success
           end
 

--- a/app/cyclid/plugins/transport.rb
+++ b/app/cyclid/plugins/transport.rb
@@ -38,7 +38,7 @@ module Cyclid
         end
 
         # Run a command on the remote host.
-        def exec(_cmd, _path = nil)
+        def exec(_cmd, _args = {})
           false
         end
 

--- a/spec/job/runner_spec.rb
+++ b/spec/job/runner_spec.rb
@@ -25,7 +25,7 @@ describe Cyclid::API::Job::Runner do
       @exit_code = 0
     end
 
-    def exec(_cmd, _path = nil)
+    def exec(_cmd, _args = {})
       true
     end
 

--- a/spec/plugins/action/command_spec.rb
+++ b/spec/plugins/action/command_spec.rb
@@ -10,9 +10,9 @@ describe Cyclid::API::Plugins::Command do
       @exit_code = 0
     end
 
-    def exec(cmd, path = nil)
+    def exec(cmd, args = {})
       @cmd = cmd
-      @path = path
+      @path = args[:path]
       true
     end
 

--- a/spec/plugins/action/script_spec.rb
+++ b/spec/plugins/action/script_spec.rb
@@ -11,9 +11,9 @@ describe Cyclid::API::Plugins::Script do
       @exit_code = 0
     end
 
-    def exec(cmd, path = nil)
+    def exec(cmd, args = {})
       @cmd = cmd
-      @path = path
+      @path = args[:path]
       true
     end
 

--- a/spec/plugins/provisioner/centos_spec.rb
+++ b/spec/plugins/provisioner/centos_spec.rb
@@ -32,7 +32,8 @@ describe Cyclid::API::Plugins::Centos do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('rpm -U -q http://example.com/repository.rpm')
+        expect(transport).to receive(:exec).with('rpm -U -q http://example.com/repository.rpm',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
@@ -46,7 +47,8 @@ describe Cyclid::API::Plugins::Centos do
       end
 
       it 'should install the package groups' do
-        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
@@ -60,7 +62,7 @@ describe Cyclid::API::Plugins::Centos do
       end
 
       it 'should install the packages' do
-        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2', sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
@@ -89,8 +91,9 @@ describe Cyclid::API::Plugins::Centos do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
-        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo')
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils', sudo: true)
+        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
@@ -104,8 +107,9 @@ describe Cyclid::API::Plugins::Centos do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
-        expect(transport).to receive(:exec).with('yum localinstall -q -y --nogpgcheck http://example.com/repository.rpm')
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils', sudo: true)
+        expect(transport).to receive(:exec).with('yum localinstall -q -y --nogpgcheck http://example.com/repository.rpm',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
@@ -119,7 +123,8 @@ describe Cyclid::API::Plugins::Centos do
       end
 
       it 'should install the package groups' do
-        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error
@@ -133,7 +138,7 @@ describe Cyclid::API::Plugins::Centos do
       end
 
       it 'should install the packages' do
-        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2', sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Centos.new }.to_not raise_error

--- a/spec/plugins/provisioner/debian_spec.rb
+++ b/spec/plugins/provisioner/debian_spec.rb
@@ -10,8 +10,9 @@ describe Cyclid::API::Plugins::Debian do
       @exit_code = 0
     end
 
-    def exec(cmd, _path = nil)
+    def exec(cmd, args = {})
       @cmd = cmd
+      @path = args[:path]
       true
     end
 

--- a/spec/plugins/provisioner/fedora_spec.rb
+++ b/spec/plugins/provisioner/fedora_spec.rb
@@ -33,9 +33,11 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
-        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
-        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo')
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils', sudo: true)
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key',
+                                                 sudo: true)
+        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
@@ -50,9 +52,11 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
-        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
-        expect(transport).to receive(:exec).with('yum install -q -y --nogpgcheck http://example.com/repository.rpm')
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils', sudo: true)
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key',
+                                                 sudo: true)
+        expect(transport).to receive(:exec).with('yum install -q -y --nogpgcheck http://example.com/repository.rpm',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
@@ -66,7 +70,8 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should install the package groups' do
-        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
@@ -80,7 +85,7 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should install the packages' do
-        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2', sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
@@ -110,9 +115,12 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with("dnf install -q -y 'dnf-command(config-manager)'")
-        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
-        expect(transport).to receive(:exec).with('dnf config-manager -q --add-repo http://example.com/repository.repo')
+        expect(transport).to receive(:exec).with("dnf install -q -y 'dnf-command(config-manager)'",
+                                                 sudo: true)
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key',
+                                                 sudo: true)
+        expect(transport).to receive(:exec).with('dnf config-manager -q --add-repo http://example.com/repository.repo',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
@@ -127,9 +135,12 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with("dnf install -q -y 'dnf-command(config-manager)'")
-        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key')
-        expect(transport).to receive(:exec).with('dnf install -q -y http://example.com/repository.rpm')
+        expect(transport).to receive(:exec).with("dnf install -q -y 'dnf-command(config-manager)'",
+                                                 sudo: true)
+        expect(transport).to receive(:exec).with('rpm -q --import http://example.com/repository.key',
+                                                 sudo: true)
+        expect(transport).to receive(:exec).with('dnf install -q -y http://example.com/repository.rpm',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
@@ -143,7 +154,8 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should install the package groups' do
-        expect(transport).to receive(:exec).with('dnf groups install -q -y "group1" "group2"')
+        expect(transport).to receive(:exec).with('dnf groups install -q -y "group1" "group2"',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error
@@ -157,7 +169,7 @@ describe Cyclid::API::Plugins::Fedora do
       end
 
       it 'should install the packages' do
-        expect(transport).to receive(:exec).with('dnf install -q -y package1 package2')
+        expect(transport).to receive(:exec).with('dnf install -q -y package1 package2', sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::Fedora.new }.to_not raise_error

--- a/spec/plugins/provisioner/redhat/helpers_spec.rb
+++ b/spec/plugins/provisioner/redhat/helpers_spec.rb
@@ -12,7 +12,7 @@ describe Cyclid::API::Plugins::Helpers::Redhat do
 
   describe '#install_yum_utils' do
     it 'uses YUM to install the yum-utils package' do
-      expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
+      expect(transport).to receive(:exec).with('yum install -q -y yum-utils', sudo: true)
       expect{ dummy_class.install_yum_utils(transport) }.to_not raise_error
     end
   end
@@ -23,7 +23,7 @@ describe Cyclid::API::Plugins::Helpers::Redhat do
     end
 
     it 'uses RPM to install the signing key' do
-      expect(transport).to receive(:exec).with("rpm  --import #{key}")
+      expect(transport).to receive(:exec).with("rpm  --import #{key}", sudo: true)
       expect{ dummy_class.import_signing_key(transport, key) }.to_not raise_error
     end
   end
@@ -34,7 +34,7 @@ describe Cyclid::API::Plugins::Helpers::Redhat do
     end
 
     it 'uses YUM to install the list of groups' do
-      expect(transport).to receive(:exec).with('yum groupinstall  -y "group1" "group2"')
+      expect(transport).to receive(:exec).with('yum groupinstall  -y "group1" "group2"', sudo: true)
       expect{ dummy_class.yum_groupinstall(transport, groups) }.to_not raise_error
     end
   end
@@ -45,7 +45,7 @@ describe Cyclid::API::Plugins::Helpers::Redhat do
     end
 
     it 'uses YUM to install the list of packages' do
-      expect(transport).to receive(:exec).with("yum install  -y #{packages.join(' ')}")
+      expect(transport).to receive(:exec).with("yum install  -y #{packages.join(' ')}", sudo: true)
       expect{ dummy_class.yum_install(transport, packages) }.to_not raise_error
     end
   end
@@ -56,7 +56,7 @@ describe Cyclid::API::Plugins::Helpers::Redhat do
     end
 
     it 'uses YUM to add the repository' do
-      expect(transport).to receive(:exec).with("yum-config-manager  --add-repo #{url}")
+      expect(transport).to receive(:exec).with("yum-config-manager  --add-repo #{url}", sudo: true)
       expect{ dummy_class.yum_add_repo(transport, url) }.to_not raise_error
     end
   end

--- a/spec/plugins/provisioner/rhel_spec.rb
+++ b/spec/plugins/provisioner/rhel_spec.rb
@@ -32,7 +32,8 @@ describe Cyclid::API::Plugins::RHEL do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('rpm -U -q http://example.com/repository.rpm')
+        expect(transport).to receive(:exec).with('rpm -U -q http://example.com/repository.rpm',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
@@ -46,7 +47,8 @@ describe Cyclid::API::Plugins::RHEL do
       end
 
       it 'should install the package groups' do
-        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
@@ -60,7 +62,7 @@ describe Cyclid::API::Plugins::RHEL do
       end
 
       it 'should install the packages' do
-        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2', sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
@@ -89,8 +91,9 @@ describe Cyclid::API::Plugins::RHEL do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
-        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo')
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils', sudo: true)
+        expect(transport).to receive(:exec).with('yum-config-manager -q --add-repo http://example.com/repository.repo',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
@@ -104,8 +107,9 @@ describe Cyclid::API::Plugins::RHEL do
       end
 
       it 'should configure the host to use the repositories' do
-        expect(transport).to receive(:exec).with('yum install -q -y yum-utils')
-        expect(transport).to receive(:exec).with('yum localinstall -q -y --nogpgcheck http://example.com/repository.rpm')
+        expect(transport).to receive(:exec).with('yum install -q -y yum-utils', sudo: true)
+        expect(transport).to receive(:exec).with('yum localinstall -q -y --nogpgcheck http://example.com/repository.rpm',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
@@ -119,7 +123,8 @@ describe Cyclid::API::Plugins::RHEL do
       end
 
       it 'should install the package groups' do
-        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"')
+        expect(transport).to receive(:exec).with('yum groupinstall -q -y "group1" "group2"',
+                                                 sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error
@@ -133,7 +138,7 @@ describe Cyclid::API::Plugins::RHEL do
       end
 
       it 'should install the packages' do
-        expect(transport).to receive(:exec).with('yum install -q -y package1 package2')
+        expect(transport).to receive(:exec).with('yum install -q -y package1 package2', sudo: true)
 
         provisioner = nil
         expect{ provisioner = Cyclid::API::Plugins::RHEL.new }.to_not raise_error

--- a/spec/plugins/provisioner/ubuntu_spec.rb
+++ b/spec/plugins/provisioner/ubuntu_spec.rb
@@ -10,8 +10,9 @@ describe Cyclid::API::Plugins::Ubuntu do
       @exit_code = 0
     end
 
-    def exec(cmd, _path = nil)
+    def exec(cmd, args = {})
       @cmd = cmd
+      @path = args[:path]
       true
     end
 

--- a/spec/plugins/source/git_spec.rb
+++ b/spec/plugins/source/git_spec.rb
@@ -9,9 +9,9 @@ describe Cyclid::API::Plugins::Git do
   class TestTransport
     attr_reader :cmd, :path
 
-    def exec(cmd, path = nil)
+    def exec(cmd, args = {})
       @cmd = cmd
-      @path = path
+      @path = args[:path]
       true
     end
   end

--- a/spec/plugins/transport/dockerapi_spec.rb
+++ b/spec/plugins/transport/dockerapi_spec.rb
@@ -41,7 +41,7 @@ describe Cyclid::API::Plugins::DockerApi do
 
       context 'with no environment variables' do
         it 'should execute a command that exits successfully' do
-          expect(container).to receive(:exec).with(['sh', '-l', '-c', 'sudo -E /bin/true'],
+          expect(container).to receive(:exec).with(['sh', '-l', '-c', '/bin/true'],
                                                    wait: 300).and_return(success)
 
           t = nil
@@ -50,7 +50,7 @@ describe Cyclid::API::Plugins::DockerApi do
         end
 
         it 'should execute a command that exits unsuccessfully' do
-          expect(container).to receive(:exec).with(['sh', '-l', '-c', 'sudo -E /bin/false'],
+          expect(container).to receive(:exec).with(['sh', '-l', '-c', '/bin/false'],
                                                    wait: 300).and_return(failure)
 
           t = nil
@@ -66,7 +66,7 @@ describe Cyclid::API::Plugins::DockerApi do
 
         # rubocop:disable LineLength
         it 'should execute a command that exits successfully' do
-          expect(container).to receive(:exec).with(['sh', '-l', '-c', 'export TEST="example";sudo -E /bin/true'],
+          expect(container).to receive(:exec).with(['sh', '-l', '-c', 'export TEST="example";/bin/true'],
                                                    wait: 300).and_return(success)
 
           t = nil
@@ -76,7 +76,7 @@ describe Cyclid::API::Plugins::DockerApi do
         end
 
         it 'should execute a command that exits unsuccessfully' do
-          expect(container).to receive(:exec).with(['sh', '-l', '-c', 'export TEST="example";sudo -E /bin/false'],
+          expect(container).to receive(:exec).with(['sh', '-l', '-c', 'export TEST="example";/bin/false'],
                                                    wait: 300).and_return(failure)
 
           t = nil


### PR DESCRIPTION
Only run a command under sudo when the caller specifically requires it via. the 'sudo' argument to Transport::exec
Improve sudo invocation by invoking a shell to run the command under.
Set the 'sudo' argument where we need it internally.
Change the Transport#exec method to accept additional arguments, including 'path', as a hash. This is a breaking change for any plugins which use Transports or derive from the Transport plugin.