### PR TITLE
Expose the 'sudo' flag to users

### DIFF
--- a/app/cyclid/plugins/action/command.rb
+++ b/app/cyclid/plugins/action/command.rb
@@ -43,8 +43,9 @@ module Cyclid
 
           Cyclid.logger.debug "cmd: '#{@cmd}' args: #{@args}"
 
-          @env = args[:env] if args.include? :env
-          @path = args[:path] if args.include? :path
+          @env = args[:env]
+          @path = args[:path]
+          @sudo = args[:sudo]
         end
 
         # Note that we don't need to explicitly use the log for transport
@@ -71,7 +72,7 @@ module Cyclid
             path = path ** @ctx unless path.nil?
 
             # Run the command
-            success = @transport.exec(cmd_args, path: path)
+            success = @transport.exec(cmd_args, path: path, sudo: @sudo)
           rescue KeyError => ex
             # Interpolation failed
             log.write "#{ex.message}\n"

--- a/app/cyclid/plugins/action/script.rb
+++ b/app/cyclid/plugins/action/script.rb
@@ -47,9 +47,8 @@ module Cyclid
                     File.join('/', 'tmp', file)
                   end
 
-          @env = args[:env] if args.include? :env
-
-          Cyclid.logger.debug "script: '#{@script}' path: #{@path}"
+          @env = args[:env]
+          @sudo = args[:sudo]
         end
 
         # Run the script action
@@ -72,7 +71,7 @@ module Cyclid
 
             # Execute the script
             log.write("Running script from #{path}...\n")
-            success = @transport.exec("chmod +x #{path} && #{path}")
+            success = @transport.exec("chmod +x #{path} && #{path}", sudo: @sudo)
           rescue KeyError => ex
             # Interpolation failed
             log.write "#{ex.message}\n"


### PR DESCRIPTION
Allow the user to set the 'sudo' flag on Command & Script actions, and pass that to the transport when we execute the command/script so that the transport can do the right thing.